### PR TITLE
Add entry note

### DIFF
--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -107,14 +107,26 @@ EOD;
 			return $is_spam;
 		}
 
-		if ( ! isset( $_POST['gf_zero_spam_key'] ) ) {
-			return true;
-		}
+		if ( ! isset( $_POST['gf_zero_spam_key'] ) || html_entity_decode( $_POST['gf_zero_spam_key'] ) !== $this->get_key() ) {
+			add_action( 'gform_entry_created', array( $this, 'add_entry_note' ) );
 
-		if ( html_entity_decode( $_POST['gf_zero_spam_key'] ) !== $this->get_key() ) {
 			return true;
 		}
 
 		return $is_spam;
 	}
+
+	/**
+	 * Adds a note to the entry once the spam status is set (GF 2.4.18+).
+	 *
+	 * @param array $entry The entry data.
+	 */
+	public function add_entry_note( $entry ) {
+		if ( rgar( $entry, 'status' ) !== 'spam' || ! method_exists( 'GFAPI', 'add_note' ) ) {
+			return;
+		}
+
+		GFAPI::add_note( $entry['id'], 0, 'Zero Spam', __( 'This entry has been marked as spam.', 'gf-zero-spam' ), 'gf-zero-spam', 'success' );
+	}
+
 }

--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -122,7 +122,12 @@ EOD;
 	 * @param array $entry The entry data.
 	 */
 	public function add_entry_note( $entry ) {
-		if ( rgar( $entry, 'status' ) !== 'spam' || ! method_exists( 'GFAPI', 'add_note' ) ) {
+
+		if ( 'spam' !== rgar( $entry, 'status' ) ) {
+			return;
+		}
+
+		if ( ! method_exists( 'GFAPI', 'add_note' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Hi @zackkatz 

How do you feel about adding a note to the entry to identify which plugin marked the entry as spam?

<img width="805" alt="Screenshot 2021-07-23 at 09 59 39" src="https://user-images.githubusercontent.com/1872371/126759937-33871ff1-de0e-4194-8d78-7b54f4734dae.png">

We are using a similar approach in the Akismet add-on.