### PR TITLE
Move setting to new spam section [DEV-4075]

### DIFF
--- a/gravityforms-zero-spam-form-settings.php
+++ b/gravityforms-zero-spam-form-settings.php
@@ -115,14 +115,19 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 * @return array
 	 */
 	function add_settings_field( $fields, $form = array() ) {
-
-		$fields['form_options']['fields'][] = array(
+		$field = array(
 			'name'          => 'enableGFZeroSpam',
 			'type'          => 'toggle',
 			'label'         => esc_html__( 'Prevent spam using Gravity Forms Zero Spam', 'gravity-forms-zero-spam' ),
 			'tooltip'       => gform_tooltip( 'enableGFZeroSpam', '', true ),
 			'default_value' => apply_filters( 'gf_zero_spam_check_key_field', true, $form ),
 		);
+
+		if ( isset( $fields['spam'] ) ) { // Spam section added in GF 2.9.21.
+			$fields['spam']['fields'][] = $field;
+		} else {
+			$fields['form_options']['fields'][] = $field;
+		}
 
 		return $fields;
 	}


### PR DESCRIPTION
Gravity Forms 2.9.21 has a new Spam Detection section on the Form Settings page, this moves the toggle to that section.

<img width="1784" height="1210" alt="test local_wp-admin_admin php_subview=settings page=gf_edit_forms id=355 view=settings" src="https://github.com/user-attachments/assets/88cf9e44-19b3-4d44-b0d1-7aa88f23a069" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Zero Spam form setting to display in the appropriate location within form settings, ensuring optimal compatibility with all supported Gravity Forms versions. The setting now adapts intelligently based on your installation's configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->