### PR TITLE
[GFZSPAM-11] Remove dependency on jQuery

### DIFF
--- a/assets/js/email-rejection.js
+++ b/assets/js/email-rejection.js
@@ -999,7 +999,7 @@
 	 * ================================================================ */
 
 	function initFieldEditor() {
-		if ( typeof window.fieldSettings === 'undefined' || typeof jQuery === 'undefined' ) {
+		if ( typeof window.fieldSettings === 'undefined' || typeof window.gform === 'undefined' ) {
 			return;
 		}
 
@@ -1016,8 +1016,10 @@
 			window.fieldSettings.email = '.email_rejection_setting';
 		}
 
-		// GF's gform_load_field_settings is a jQuery event, so jQuery is required.
-		jQuery( document ).on( 'gform_load_field_settings', ( _event, field ) => {
+		// Use GF's vanilla JS hook fired right after the jQuery gform_load_field_settings event.
+		gform.addAction( 'gform_post_load_field_settings', ( args ) => {
+			const field = args[ 0 ];
+
 			if ( field.type !== 'email' ) {
 				return;
 			}
@@ -1063,7 +1065,7 @@
 			}
 		}
 
-		// GF form editor: bind field settings via jQuery event.
+		// GF form editor: bind field settings via gform.addAction().
 		initFieldEditor();
 	}
 

--- a/includes/class-email-rejection-field-settings.php
+++ b/includes/class-email-rejection-field-settings.php
@@ -65,7 +65,7 @@ class GF_Zero_Spam_Email_Rejection_Field_Settings {
 		wp_enqueue_script(
 			'gf-zero-spam',
 			$plugin_dir . 'dist/js/gf-zero-spam.js',
-			[ 'jquery' ],
+			[],
 			$version,
 			true
 		);

--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -426,7 +426,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 						'label'   => esc_html__( 'Send Test Email & Save Settings', 'gravity-forms-zero-spam' ),
 						'value'   => esc_html__( 'Send Email & Save Settings', 'gravity-forms-zero-spam' ),
 						'class'   => 'button',
-						'onclick' => 'jQuery( "#gf_zero_spam_test_email" ).val( "1" ); jQuery( "#gform-settings-save" ).click();',
+						'onclick' => 'document.getElementById("gf_zero_spam_test_email").value = "1"; document.getElementById("gform-settings-save").click();',
 					],
 				],
 			],

--- a/includes/class-gf-zero-spam.php
+++ b/includes/class-gf-zero-spam.php
@@ -162,7 +162,7 @@ class GF_Zero_Spam {
 	 *
 	 * @since 1.0
 	 *
-	 * @uses GFFormDisplay::add_init_script() to inject the code into the `gform_post_render` jQuery hook.
+	 * @uses GFFormDisplay::add_init_script() to inject the code into the `gform_post_render` hook.
 	 *
 	 * @param array $form The Form Object.
 	 *
@@ -200,16 +200,19 @@ class GF_Zero_Spam {
 				});
 EOD;
 		} else {
-			$autocomplete = RGFormsModel::is_html5_enabled() ? ".attr( 'autocomplete', 'new-password' )\n\t\t" : '';
+			$autocomplete = RGFormsModel::is_html5_enabled() ? "\n\t\t\t\t\t    input.setAttribute('autocomplete', 'new-password');" : '';
 
 			$script = <<<EOD
-				jQuery( "#gform_{$form_id}" ).on( 'submit', function( event ) {
-					jQuery( '<input>' )
-						.attr( 'type', 'hidden' )
-						.attr( 'name', 'gf_zero_spam_key' )
-						.attr( 'value', '{$spam_key}' )
-						$autocomplete.appendTo( jQuery( this ) );
-				} );
+				var form = document.getElementById('gform_{$form_id}');
+				if (form) {
+				    form.addEventListener('submit', function() {
+				        var input = document.createElement('input');
+				        input.type = 'hidden';
+				        input.name = 'gf_zero_spam_key';
+				        input.value = '{$spam_key}';{$autocomplete}
+				        this.appendChild(input);
+				    });
+				}
 EOD;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ You can enable a spam summary report email. This email will be sent to the email
 = develop =
 
 * Fixed: "Prevent spam using Gravity Forms Zero Spam" toggle appeared twice in form settings
+* Improved: Removed dependency on jQuery
 
 = 1.5.0 on February 26, 2026 =
 


### PR DESCRIPTION
## Summary
- Replaced all jQuery usage with vanilla DOM APIs and Gravity Forms' native event system
- Legacy form submit handler (pre-GF 2.9.0) now uses `getElementById` and `addEventListener`
- Settings page onclick handler uses `document.getElementById` with direct property access
- Form editor field settings use `gform.addAction('gform_post_load_field_settings')` instead of jQuery event
- Removed jQuery from `wp_enqueue_script` dependency array

## Test plan
- [ ] Submit a form and verify the spam key is injected correctly (no spam false positives)
- [ ] Open the Zero Spam settings page and click "Send Test Email & Save Settings" — verify it works
- [ ] Open the form editor, click an Email field, open Advanced settings — verify email rejection rules appear
- [ ] Verify no JavaScript errors in the browser console related to Zero Spam
- [ ] Test on a site where jQuery is not loaded on the frontend

[GFZSPAM-11](https://linear.app/gravitykit/issue/GFZSPAM-11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Removed the plugin's jQuery dependency and replaced jQuery-based interactions with native JavaScript for settings, form behavior, and the test-email flow.
  * Updated documentation/changelog to reflect the removal of jQuery, improving performance and reducing external dependency surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/8poao7zo7uektml61ji2q/gravity-forms-zero-spam-1.5.0-fcf1949.zip?rlkey=rp3s11udq6pgryx8xwdgtzlnr&dl=1) (fcf1949).