### PR TITLE
Add Shield silentCAPTCHA integration

### DIFF
--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -10,6 +10,7 @@ GFForms::include_addon_framework();
 require_once GF_ZERO_SPAM_DIR . 'includes/class-email-rejection.php';
 require_once GF_ZERO_SPAM_DIR . 'includes/class-email-rejection-settings.php';
 require_once GF_ZERO_SPAM_DIR . 'includes/class-email-rejection-field-settings.php';
+require_once GF_ZERO_SPAM_DIR . 'includes/class-gf-zero-spam-shield-silent-captcha.php';
 
 /**
  * @since 1.2
@@ -65,6 +66,11 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	private $email_rejection_settings;
 
 	/**
+	 * Shield silentCAPTCHA integration instance.
+	 */
+	private ?GF_Zero_Spam_Shield_Silent_Captcha $shield_silent_captcha = null;
+
+	/**
 	 * Gets the singleton instance.
 	 *
 	 * @since 1.5.0
@@ -100,6 +106,9 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 
 		$email_rejection_field_settings = new GF_Zero_Spam_Email_Rejection_Field_Settings();
 		$email_rejection_field_settings->init();
+
+		$this->shield_silent_captcha = new GF_Zero_Spam_Shield_Silent_Captcha( $this );
+		$this->shield_silent_captcha->init();
 
 		parent::init();
 
@@ -437,6 +446,10 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 			$sections = $this->email_rejection_settings->add_settings_section( $sections );
 		}
 
+		if ( $this->shield_silent_captcha ) {
+			$sections = $this->shield_silent_captcha->add_plugin_settings_fields( $sections );
+		}
+
 		return $sections;
 	}
 
@@ -452,6 +465,9 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	public function update_plugin_settings( $settings ) {
 		if ( $this->email_rejection_settings ) {
 			$settings = $this->email_rejection_settings->save_rules_from_post( $settings );
+		}
+		if ( $this->shield_silent_captcha ) {
+			$settings = $this->shield_silent_captcha->normalize_plugin_settings( $settings );
 		}
 
 		parent::update_plugin_settings( $settings );

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -1,0 +1,768 @@
+<?php
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Shield silentCAPTCHA integration for Gravity Forms Zero Spam.
+ */
+class GF_Zero_Spam_Shield_Silent_Captcha {
+
+	private const SETTING_KEY      = 'shield_silent_captcha';
+	private const PERSIST_KEY      = 'shield_silent_captcha_persist';
+	private const STATUS_FIELD_KEY = 'shield_silent_captcha_status';
+	private const HELP_URL         = 'https://clk.shldscrty.com/gravityformszerospamsilentcaptcha';
+	private const SPAM_FILTER_NAME = 'Shield silentCAPTCHA';
+
+	/**
+	 * Add-on instance.
+	 */
+	private GF_Zero_Spam_AddOn $addon;
+
+	/**
+	 * Cached Shield availability after plugins_loaded.
+	 */
+	private ?bool $shield_available = null;
+
+	/**
+	 * Cached threshold-zero state after plugins_loaded.
+	 */
+	private ?bool $shield_threshold_zero = null;
+
+	/**
+	 * Shield-flagged form IDs used for the entry-note fallback path.
+	 *
+	 * @var array<int, bool>
+	 */
+	private array $flagged_forms = [];
+
+	public function __construct( GF_Zero_Spam_AddOn $addon ) {
+		$this->addon = $addon;
+	}
+
+	/**
+	 * Registers Shield hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'gform_form_settings_fields', [ $this, 'add_form_settings_fields' ], 11, 2 );
+		add_filter( 'gform_form_settings_before_save', [ $this, 'normalize_form_settings' ] );
+		add_filter( 'gform_tooltips', [ $this, 'add_tooltips' ] );
+		add_filter( 'gform_entry_is_spam', [ $this, 'filter_entry_is_spam' ], 20, 3 );
+		add_filter( 'gform_abort_submission_with_confirmation', [ $this, 'maybe_abort_submission' ], 30, 2 );
+		add_action( 'gform_entry_created', [ $this, 'maybe_add_entry_note' ] );
+	}
+
+	/**
+	 * Adds Shield fields to the existing Spam Blocking plugin settings section.
+	 *
+	 * @param array $sections Settings sections.
+	 *
+	 * @return array
+	 */
+	public function add_plugin_settings_fields( $sections ) {
+		$shield_fields = $this->get_plugin_settings_fields();
+
+		foreach ( $sections as &$section ) {
+			if ( ! isset( $section['fields'] ) || ! is_array( $section['fields'] ) ) {
+				continue;
+			}
+
+			if ( ! $this->section_contains_field( $section, 'gf_zero_spam_blocking' ) ) {
+				continue;
+			}
+
+			$section['fields'] = $this->insert_fields_after_name( $section['fields'], 'gf_zero_spam_blocking', $shield_fields );
+			break;
+		}
+
+		return $sections;
+	}
+
+	/**
+	 * Normalizes Shield plugin settings before save.
+	 *
+	 * @param array $settings Settings array.
+	 *
+	 * @return array
+	 */
+	public function normalize_plugin_settings( $settings ) {
+		$submitted = $settings[ self::SETTING_KEY ] ?? null;
+		$persisted = rgar( $settings, self::PERSIST_KEY );
+
+		if ( null === $persisted ) {
+			$persisted = rgpost( '_gform_setting_' . self::PERSIST_KEY );
+		}
+
+		$settings[ self::SETTING_KEY ] = $this->resolve_setting_value_for_save(
+			$submitted,
+			$persisted,
+			$this->get_plugin_setting_value()
+		);
+
+		unset( $settings[ self::PERSIST_KEY ], $settings[ self::STATUS_FIELD_KEY ] );
+
+		return $settings;
+	}
+
+	/**
+	 * Adds Shield per-form fields after the existing Zero Spam toggle.
+	 *
+	 * @param array $fields Settings sections.
+	 * @param array $form   Current form object.
+	 *
+	 * @return array
+	 */
+	public function add_form_settings_fields( $fields, $form ) {
+		$section_key = isset( $fields['spam'] ) ? 'spam' : 'form_options';
+
+		if ( ! isset( $fields[ $section_key ]['fields'] ) || ! is_array( $fields[ $section_key ]['fields'] ) ) {
+			return $fields;
+		}
+
+		$fields[ $section_key ]['fields'] = $this->insert_fields_after_name(
+			$fields[ $section_key ]['fields'],
+			'enableGFZeroSpam',
+			$this->get_form_settings_fields( $form )
+		);
+
+		return $fields;
+	}
+
+	/**
+	 * Normalizes Shield form settings before save.
+	 *
+	 * @param array $form Form object.
+	 *
+	 * @return array
+	 */
+	public function normalize_form_settings( $form ) {
+		$submitted = rgpost( self::SETTING_KEY );
+		$persisted  = rgpost( self::PERSIST_KEY );
+
+		$form[ self::SETTING_KEY ] = $this->resolve_setting_value_for_save(
+			$submitted,
+			$persisted,
+			$this->get_effective_form_setting_value( $form )
+		);
+
+		unset( $form[ self::PERSIST_KEY ], $form[ self::STATUS_FIELD_KEY ] );
+
+		return $form;
+	}
+
+	/**
+	 * Adds the Shield form-settings tooltip.
+	 *
+	 * @param array $tooltips Existing tooltips.
+	 *
+	 * @return array
+	 */
+	public function add_tooltips( $tooltips ) {
+		if ( is_array( $tooltips ) ) {
+			$tooltips[ self::SETTING_KEY ] = esc_html( $this->get_form_tooltip_text( $this->addon->get_current_form() ) );
+		}
+
+		return $tooltips;
+	}
+
+	/**
+	 * Flags the entry as spam when Shield returns a strict true verdict.
+	 *
+	 * @param bool  $is_spam Existing spam state.
+	 * @param array $form    Form object.
+	 * @param array $entry   Entry object.
+	 *
+	 * @return bool
+	 */
+	public function filter_entry_is_spam( $is_spam, $form, $entry ) {
+		if ( $is_spam ) {
+			return $is_spam;
+		}
+
+		if ( GFCommon::current_user_can_any( 'gravityforms_edit_entries' ) ) {
+			return false;
+		}
+
+		if ( ! $this->is_submission_context_supported( $form, $entry ) ) {
+			return $is_spam;
+		}
+
+		if ( ! $this->is_shield_enabled_for_form( $form ) ) {
+			return $is_spam;
+		}
+
+		if ( true !== $this->resolve_shield_bot_verdict() ) {
+			return $is_spam;
+		}
+
+		$form_id = (int) rgar( $form, 'id' );
+
+		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
+			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf(__( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), 'Shield silentCAPTCHA' ) );
+		} else {
+			$this->flagged_forms[ $form_id ] = true;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Aborts Save and Continue draft creation when Shield returns a strict true verdict.
+	 *
+	 * @param bool  $do_abort Existing abort state.
+	 * @param array $form     Form object.
+	 *
+	 * @return bool
+	 */
+	public function maybe_abort_submission( $do_abort, $form ) {
+		if ( $do_abort || GFCommon::current_user_can_any( 'gravityforms_edit_entries' ) ) {
+			return $do_abort;
+		}
+
+		if ( ! rgpost( 'gform_save' ) || GFCommon::is_preview() ) {
+			return false;
+		}
+
+		if ( ! $this->is_shield_enabled_for_form( $form ) ) {
+			return false;
+		}
+
+		return true === $this->resolve_shield_bot_verdict();
+	}
+
+	/**
+	 * Adds a fallback entry note when GFCommon::set_spam_filter() is unavailable.
+	 *
+	 * @param array $entry Entry object.
+	 *
+	 * @return void
+	 */
+	public function maybe_add_entry_note( $entry ) {
+		$form_id = (int) rgar( $entry, 'form_id' );
+
+		if ( 'spam' !== rgar( $entry, 'status' ) || empty( $this->flagged_forms[ $form_id ] ) ) {
+			return;
+		}
+
+		if ( ! method_exists( 'GFAPI', 'add_note' ) ) {
+			return;
+		}
+
+		GFAPI::add_note(
+			$entry['id'],
+			0,
+			self::SPAM_FILTER_NAME,
+			__( 'This entry has been marked as spam by Shield silentCAPTCHA.', 'gravity-forms-zero-spam' ),
+			'gf-zero-spam',
+			'warning'
+		);
+
+		unset( $this->flagged_forms[ $form_id ] );
+	}
+
+	/**
+	 * Renders the plugin-settings status/help field.
+	 *
+	 * @param array $field Field config.
+	 * @param bool  $echo  Whether to echo markup.
+	 */
+	public function render_plugin_status_field( $field, $echo = true ): ?string {
+		$html = $this->render_plugin_status_message();
+
+		if ( ! $this->is_shield_available() ) {
+			$html .= $this->render_disable_control_script( [ '_gform_setting_' . self::SETTING_KEY, self::SETTING_KEY ] );
+		}
+
+		if ( $echo ) {
+			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is escaped at source.
+
+			return null;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Renders the hidden form-settings field used only for the disable-script fallback.
+	 *
+	 * @param array $field Field config.
+	 * @param bool  $echo  Whether to echo markup.
+	 */
+	public function render_form_status_field( $field, $echo = true ): ?string {
+		$html = '';
+
+		if ( ! $this->is_shield_available() ) {
+			$html = $this->render_disable_control_script( [ '_gform_setting_' . self::SETTING_KEY, self::SETTING_KEY ] );
+		} elseif ( $this->is_threshold_zero() ) {
+			$html = sprintf(
+				'<p class="description" style="color:#996800;">%s</p>',
+				esc_html( $this->get_form_tooltip_text( $this->addon->get_current_form() ) )
+			);
+		}
+
+		if ( $echo ) {
+			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is escaped at source.
+
+			return null;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Builds the Shield plugin settings field definitions.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_plugin_settings_fields(): array {
+		return [
+			[
+				'label'         => esc_html__( 'Enable Shield silentCAPTCHA by Default', 'gravity-forms-zero-spam' ),
+				'type'          => 'toggle',
+				'name'          => self::SETTING_KEY,
+				'default_value' => $this->get_plugin_setting_value(),
+				'disabled'      => ! $this->is_shield_available(),
+			],
+			[
+				'type'          => 'hidden',
+				'name'          => self::PERSIST_KEY,
+				'default_value' => $this->get_plugin_setting_value(),
+			],
+			[
+				'type'     => 'html',
+				'name'     => self::STATUS_FIELD_KEY,
+				'label'    => '',
+				'callback' => [ $this, 'render_plugin_status_field' ],
+			],
+		];
+	}
+
+	/**
+	 * Builds the Shield form settings field definitions.
+	 *
+	 * @param array $form Form object.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_form_settings_fields( $form ): array {
+		$current_value = $this->get_effective_form_setting_value( $form );
+
+		return [
+			[
+				'name'          => self::SETTING_KEY,
+				'type'          => 'toggle',
+				'label'         => esc_html__( 'Enable Shield silentCAPTCHA for this form', 'gravity-forms-zero-spam' ),
+				'tooltip'       => gform_tooltip( self::SETTING_KEY, '', true ),
+				'default_value' => $current_value,
+				'disabled'      => ! $this->is_shield_available(),
+			],
+			[
+				'type'          => 'hidden',
+				'name'          => self::PERSIST_KEY,
+				'default_value' => $current_value,
+			],
+			[
+				'hidden'   => ! $this->is_threshold_zero(),
+				'type'     => 'html',
+				'name'     => self::STATUS_FIELD_KEY,
+				'label'    => '',
+				'callback' => [ $this, 'render_form_status_field' ],
+			],
+		];
+	}
+
+	/**
+	 * Returns the stored global Shield setting in normalized string form.
+	 */
+	private function get_plugin_setting_value(): string {
+		return $this->normalize_setting_value( $this->addon->get_plugin_setting( self::SETTING_KEY ) );
+	}
+
+	/**
+	 * Determines whether the form has a saved Shield setting.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function has_saved_form_setting( $form ): bool {
+		return is_array( $form ) && array_key_exists( self::SETTING_KEY, $form );
+	}
+
+	/**
+	 * Returns the saved per-form Shield setting when present.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function get_saved_form_setting_value( $form ): ?string {
+		if ( ! $this->has_saved_form_setting( $form ) ) {
+			return null;
+		}
+
+		return $this->normalize_setting_value( $form[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Returns the effective Shield setting for the form.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function get_effective_form_setting_value( $form ): string {
+		$saved_value = $this->get_saved_form_setting_value( $form );
+
+		return null !== $saved_value ? $saved_value : $this->get_plugin_setting_value();
+	}
+
+	/**
+	 * Determines if Shield is enabled for the current form.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function is_shield_enabled_for_form( $form ): bool {
+		return '1' === $this->get_effective_form_setting_value( $form );
+	}
+
+	/**
+	 * Normalizes a stored toggle value into the committed string shape.
+	 *
+	 * @param mixed $value Raw value.
+	 */
+	private function normalize_setting_value( $value ): string {
+		return in_array( (string) $value, [ '1', 'true', 'on', 'yes' ], true ) ? '1' : '0';
+	}
+
+	/**
+	 * Resolves the stored Shield setting value during a save operation.
+	 *
+	 * @param mixed  $submitted     Submitted toggle value, if present.
+	 * @param mixed  $persisted     Hidden persisted value, if present.
+	 * @param string $current_value Current stored normalized value.
+	 */
+	private function resolve_setting_value_for_save( $submitted, $persisted, string $current_value ): string {
+		if ( null !== $submitted ) {
+			return $this->normalize_setting_value( $submitted );
+		}
+
+		if ( ! $this->is_shield_available() ) {
+			if ( null !== $persisted ) {
+				return $this->normalize_setting_value( $persisted );
+			}
+
+			return $current_value;
+		}
+
+		return '0';
+	}
+
+	/**
+	 * Determines if the current request is a supported submission context.
+	 *
+	 * @param array $form  Form object.
+	 * @param array $entry Entry object.
+	 */
+	private function is_submission_context_supported( $form, $entry ): bool {
+		if ( GFCommon::is_preview() ) {
+			return false;
+		}
+
+		$supports_context = method_exists( 'GFFormDisplay', 'get_submission_context' );
+		if ( $supports_context && GFFormDisplay::get_submission_context() !== 'form-submit' ) {
+			return false;
+		}
+
+		if ( ! $supports_context && ! did_action( 'gform_pre_submission' ) ) {
+			return false;
+		}
+
+		return !( isset( $entry['user_agent'] ) && 'API' === $entry['user_agent'] );
+	}
+
+	/**
+	 * Resolves the Shield verdict using the documented callable order.
+	 */
+	private function resolve_shield_bot_verdict(): ?bool {
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			return null;
+		}
+
+		foreach ( $this->get_shield_callables() as $callable ) {
+			if ( ! is_callable( $callable ) ) {
+				continue;
+			}
+
+			try {
+				$verdict = call_user_func( $callable );
+			} catch ( \Throwable $e ) {
+				continue;
+			}
+
+			$normalized = $this->normalize_verdict( $verdict );
+			if ( null !== $normalized ) {
+				return $normalized;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determines if Shield is available for the current request.
+	 */
+	private function is_shield_available(): bool {
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			return false;
+		}
+
+		if ( null !== $this->shield_available ) {
+			return $this->shield_available;
+		}
+
+		$this->shield_available = false;
+
+		foreach ( $this->get_shield_callables() as $callable ) {
+			if ( is_callable( $callable ) ) {
+				$this->shield_available = true;
+				break;
+			}
+		}
+
+		return $this->shield_available;
+	}
+
+	/**
+	 * Determines if Shield is available and the threshold is zero.
+	 */
+	private function is_threshold_zero(): bool {
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			return false;
+		}
+
+		if ( null !== $this->shield_threshold_zero ) {
+			return $this->shield_threshold_zero;
+		}
+
+		$this->shield_threshold_zero = false;
+
+		if ( ! $this->is_shield_available() ) {
+			return $this->shield_threshold_zero;
+		}
+
+		foreach ( $this->get_shield_threshold_callables() as $callable ) {
+			if ( ! is_callable( $callable ) ) {
+				continue;
+			}
+
+			try {
+				$threshold = call_user_func( $callable );
+			} catch ( \Throwable $e ) {
+				continue;
+			}
+
+			if ( ! is_numeric( $threshold ) ) {
+				continue;
+			}
+
+			$this->shield_threshold_zero = 0 === (int) $threshold;
+			break;
+		}
+
+		return $this->shield_threshold_zero;
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	private function get_shield_callables(): array {
+		return [
+			'\\FernleafSystems\\Wordpress\\Plugin\\Shield\\Functions\\test_ip_is_bot',
+			'shield_test_ip_is_bot',
+		];
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	private function get_shield_threshold_callables(): array {
+		return [
+			'\\FernleafSystems\\Wordpress\\Plugin\\Shield\\Functions\\get_silentcaptcha_bot_threshold',
+			'shield_get_silentcaptcha_bot_threshold',
+		];
+	}
+
+	/**
+	 * Normalizes the Shield verdict into a strict tri-state.
+	 *
+	 * @param mixed $verdict Raw verdict.
+	 */
+	private function normalize_verdict( $verdict ): ?bool {
+		if ( true === $verdict ) {
+			return true;
+		}
+
+		if ( false === $verdict ) {
+			return false;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the form tooltip text for the current Shield state.
+	 */
+	private function get_form_tooltip_text( $form ): string {
+		$setting_scope = $this->get_form_setting_scope_text( $form );
+
+		if ( ! $this->is_shield_available() ) {
+			return $setting_scope . ' ' . $this->get_unavailable_message();
+		}
+
+		if ( $this->is_threshold_zero() ) {
+			return $setting_scope . ' ' . $this->get_threshold_zero_message();
+		}
+
+		return $setting_scope . ' ' . $this->get_form_help_text();
+	}
+
+	/**
+	 * Returns the plugin-settings status text for the current Shield state.
+	 */
+	private function get_plugin_status_text(): string {
+		if ( ! $this->is_shield_available() ) {
+			return $this->get_unavailable_message();
+		}
+
+		if ( $this->is_threshold_zero() ) {
+			return $this->get_threshold_zero_message();
+		}
+
+		return $this->get_global_help_text();
+	}
+
+	/**
+	 * Renders the plugin-settings status message with the Learn More link.
+	 */
+	private function render_plugin_status_message(): string {
+		$style = $this->is_shield_available() && $this->is_threshold_zero()
+			? ' style="color:#996800;"'
+			: '';
+
+		return sprintf(
+			'<p class="description"%s>%s <a href="%s" target="_blank" rel="noopener noreferrer">%s</a></p>',
+			$style,
+			esc_html( $this->get_plugin_status_text() ),
+			esc_url( self::HELP_URL ),
+			esc_html__( 'Learn More', 'gravity-forms-zero-spam' )
+		);
+	}
+
+	/**
+	 * Creates a tiny inline script to disable the visible Shield toggle.
+	 *
+	 * @param array<int, string> $field_names Candidate field names.
+	 */
+	private function render_disable_control_script( $field_names ): string {
+		$field_names_json = wp_json_encode( array_values( $field_names ) );
+
+		return <<<HTML
+<script>
+(function() {
+	'use strict';
+
+	const names = {$field_names_json};
+
+	function disableByName() {
+		for ( let i = 0; i < names.length; i++ ) {
+			const inputs = document.getElementsByName( names[i] );
+
+			for ( let j = 0; j < inputs.length; j++ ) {
+				if ( 'checkbox' === inputs[j].type || 'radio' === inputs[j].type ) {
+					inputs[j].disabled = true;
+				}
+			}
+		}
+	}
+
+	if ( 'loading' === document.readyState ) {
+		document.addEventListener( 'DOMContentLoaded', disableByName );
+		return;
+	}
+
+	disableByName();
+})();
+</script>
+HTML;
+	}
+
+	/**
+	 * Determines whether the section contains a given field name.
+	 *
+	 * @param array  $section    Section config.
+	 * @param string $field_name Field name.
+	 */
+	private function section_contains_field( $section, $field_name ): bool {
+		foreach ( $section['fields'] as $field ) {
+			if ( rgar( $field, 'name' ) === $field_name ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Inserts fields immediately after a named field, appending if not found.
+	 *
+	 * @param array  $fields     Existing fields.
+	 * @param string $field_name Target field name.
+	 * @param array  $new_fields Fields to insert.
+	 */
+	private function insert_fields_after_name( $fields, $field_name, $new_fields ): array {
+		$updated  = [];
+		$inserted = false;
+
+		foreach ( $fields as $field ) {
+			$updated[] = $field;
+
+			if ( rgar( $field, 'name' ) === $field_name ) {
+				foreach ( $new_fields as $new_field ) {
+					$updated[] = $new_field;
+				}
+
+				$inserted = true;
+			}
+		}
+
+		if ( ! $inserted ) {
+			foreach ( $new_fields as $new_field ) {
+				$updated[] = $new_field;
+			}
+		}
+
+		return $updated;
+	}
+
+	private function get_form_setting_scope_text( $form ): string {
+		if ( $this->has_saved_form_setting( $form ) ) {
+			return __( 'This setting is currently overriding the global default setting.', 'gravity-forms-zero-spam' );
+		}
+
+		return __( 'This setting is currently inheriting the global default setting.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_form_help_text(): string {
+		return __( 'Runs Shield silentCAPTCHA server-side for this form. No field needs to be added to the form.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_global_help_text(): string {
+		return __( 'Enable Shield silentCAPTCHA by default for forms. No field needs to be added to the form. Forms without their own Shield setting will use this default.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_unavailable_message(): string {
+		return __( 'Shield silentCAPTCHA is currently unavailable because Shield Security is not installed or active. This setting is disabled until Shield becomes available again.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_threshold_zero_message(): string {
+		return __( 'Shield silentCAPTCHA is available, but Shield\'s bot threshold is 0, so it will not flag submissions until that threshold is increased.', 'gravity-forms-zero-spam' );
+	}
+}

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -48,7 +48,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 */
 	public function init() {
 		add_filter( 'gform_form_settings_fields', [ $this, 'add_form_settings_fields' ], 11, 2 );
-		add_filter( 'gform_form_settings_before_save', [ $this, 'normalize_form_settings' ] );
+		add_filter( 'gform_pre_form_settings_save', [ $this, 'normalize_form_settings' ] );
 		add_filter( 'gform_tooltips', [ $this, 'add_tooltips' ] );
 		add_filter( 'gform_entry_is_spam', [ $this, 'filter_entry_is_spam' ], 20, 3 );
 		add_filter( 'gform_abort_submission_with_confirmation', [ $this, 'maybe_abort_submission' ], 30, 2 );
@@ -139,14 +139,18 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * @return array
 	 */
 	public function normalize_form_settings( $form ) {
-		$submitted = rgpost( self::SETTING_KEY );
-		$persisted  = rgpost( self::PERSIST_KEY );
+		$submitted         = rgpost( '_gform_setting_' . self::SETTING_KEY );
+		$persisted         = rgpost( '_gform_setting_' . self::PERSIST_KEY );
+		$had_saved_setting = $this->has_saved_form_setting( $form );
+		$current_value     = $this->get_effective_form_setting_value( $form );
+		$resolved          = $this->resolve_setting_value_for_save( $submitted, $persisted, $current_value );
 
-		$form[ self::SETTING_KEY ] = $this->resolve_setting_value_for_save(
-			$submitted,
-			$persisted,
-			$this->get_effective_form_setting_value( $form )
-		);
+		// Keep missing-key inheritance intact unless the form already had an override or the user changed the value.
+		if ( ! $had_saved_setting && $resolved === $current_value ) {
+			unset( $form[ self::SETTING_KEY ] );
+		} else {
+			$form[ self::SETTING_KEY ] = $resolved;
+		}
 
 		unset( $form[ self::PERSIST_KEY ], $form[ self::STATUS_FIELD_KEY ] );
 
@@ -286,7 +290,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	}
 
 	/**
-	 * Renders the hidden form-settings field used only for the disable-script fallback.
+	 * Renders the form-settings status field.
+	 *
+	 * Emits the disable-script fallback when Shield is unavailable and the inline
+	 * threshold warning when Shield is available but its bot threshold is zero.
 	 *
 	 * @param array $field Field config.
 	 * @param bool  $echo  Whether to echo markup.

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -57,12 +57,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Adds Shield fields to the existing Spam Blocking plugin settings section.
-	 *
-	 * @param array $sections Settings sections.
-	 *
-	 * @return array
 	 */
-	public function add_plugin_settings_fields( $sections ) {
+	public function add_plugin_settings_fields( array $sections ): array {
 		$shield_fields = $this->get_plugin_settings_fields();
 
 		foreach ( $sections as &$section ) {
@@ -160,9 +156,12 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Adds the Shield form-settings tooltip.
 	 *
-	 * @param array $tooltips Existing tooltips.
+	 * Public filter boundary. Gravity Forms intends this value to be an array,
+	 * but other callbacks can still pass through a non-array value.
 	 *
-	 * @return array
+	 * @param mixed $tooltips Existing tooltips.
+	 *
+	 * @return mixed
 	 */
 	public function add_tooltips( $tooltips ) {
 		if ( is_array( $tooltips ) ) {
@@ -190,7 +189,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			return false;
 		}
 
-		if ( ! $this->is_submission_context_supported( $form, $entry ) ) {
+		if ( ! $this->is_submission_context_supported( $entry ) ) {
 			return $is_spam;
 		}
 
@@ -205,7 +204,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 		$form_id = (int) rgar( $form, 'id' );
 
 		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
-			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf(__( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), 'Shield silentCAPTCHA' ) );
+			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf(__( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ) );
 		} else {
 			$this->flagged_forms[ $form_id ] = true;
 		}
@@ -259,7 +258,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			$entry['id'],
 			0,
 			self::SPAM_FILTER_NAME,
-			__( 'This entry has been marked as spam by Shield silentCAPTCHA.', 'gravity-forms-zero-spam' ),
+			sprintf( __( 'This entry has been marked as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ),
 			'gf-zero-spam',
 			'warning'
 		);
@@ -465,10 +464,9 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Determines if the current request is a supported submission context.
 	 *
-	 * @param array $form  Form object.
 	 * @param array $entry Entry object.
 	 */
-	private function is_submission_context_supported( $form, $entry ): bool {
+	private function is_submission_context_supported( $entry ): bool {
 		if ( GFCommon::is_preview() ) {
 			return false;
 		}
@@ -618,7 +616,9 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * Returns the form tooltip text for the current Shield state.
 	 */
 	private function get_form_tooltip_text( $form ): string {
-		$setting_scope = $this->get_form_setting_scope_text( $form );
+		$setting_scope = $this->has_saved_form_setting( $form )
+			? __( 'This setting is currently overriding the global default setting.', 'gravity-forms-zero-spam' )
+			: __( 'This setting is currently inheriting the global default setting.', 'gravity-forms-zero-spam' );
 
 		if ( ! $this->is_shield_available() ) {
 			return $setting_scope . ' ' . $this->get_unavailable_message();
@@ -747,14 +747,6 @@ HTML;
 		}
 
 		return $updated;
-	}
-
-	private function get_form_setting_scope_text( $form ): string {
-		if ( $this->has_saved_form_setting( $form ) ) {
-			return __( 'This setting is currently overriding the global default setting.', 'gravity-forms-zero-spam' );
-		}
-
-		return __( 'This setting is currently inheriting the global default setting.', 'gravity-forms-zero-spam' );
 	}
 
 	private function get_form_help_text(): string {


### PR DESCRIPTION
# Add Shield silentCAPTCHA Integration

## Summary

This PR adds an optional Shield silentCAPTCHA integration to Gravity Forms Zero Spam.

The goal is simple:

- let sites use Shield as an extra server-side spam signal
- keep the existing Zero Spam behavior intact
- make the settings understandable at both the global and per-form level
- avoid breaking submissions if Shield is missing, disabled, or returns something unexpected

## Where To Look

Start here:

- `includes/class-gf-zero-spam-addon.php`
- `includes/class-gf-zero-spam-shield-silent-captcha.php`

`class-gf-zero-spam-addon.php` only does the wiring:

- loads the new Shield integration class
- initializes it
- lets it add plugin settings
- lets it normalize Shield settings before save

`class-gf-zero-spam-shield-silent-captcha.php` contains the actual implementation:

- settings
- saved-value normalization
- global default / per-form override logic
- Shield verdict handling
- admin UI messages

Useful methods to review first:

- `filter_entry_is_spam()`
- `maybe_abort_submission()`
- `normalize_plugin_settings()`
- `normalize_form_settings()`
- `get_effective_form_setting_value()`
- `resolve_shield_bot_verdict()`
- `render_plugin_status_field()`
- `render_form_status_field()`

## Main Behavior

### Runtime

Shield is only used as an extra spam signal.

- if Gravity Forms already marked the entry as spam, we leave that alone
- if Shield returns strict `true`, we mark the entry as spam
- if Shield returns `false`, `null`, throws, or is unavailable, we do not block the submission

This is intentionally fail-open. A broken or missing Shield integration should not interrupt form submissions.

Save and Continue follows the same rule:

- if something already asked to abort, we do not interfere
- if Shield returns strict `true`, we abort draft creation
- otherwise we leave the request alone

If Gravity Forms cannot record the spam filter directly, the integration falls back to adding an entry note. That is why the class tracks flagged form IDs during the request.

### Default And Override Logic

The plugin setting is the default.

- if a form has no saved Shield value, it inherits the global default
- if a form has a saved Shield value, that value overrides the global default

This is based on whether the form key exists, not just whether the value is on or off.

That matters because:

- missing form key = inherit
- saved `0` = explicit override off
- saved `1` = explicit override on

There is no separate inherit/override control in the UI. The current form toggle is still a single on/off control.

That means:

- untouched forms inherit the global setting
- once a form settings page is saved, the displayed value becomes that form's explicit override

## Settings And Save Handling

Both the global and per-form Shield settings use:

- the real visible toggle
- a hidden persist field
- an HTML status/help field

The hidden persist field exists so a disabled Shield toggle does not accidentally save as off just because the browser did not submit it.

The Shield status field is an HTML field, not a fake text field, so Gravity Forms does not try to validate it like a normal saved setting.

## Admin UI Behavior

### Global Settings

The global setting is labelled as the default for forms.

The message under it changes by Shield state:

- unavailable
- threshold is zero
- normal help

### Per-Form Settings

The per-form tooltip now explains two things:

- whether the form is currently inheriting or overriding the global default
- the current Shield state for that form context

The per-form inline help below the toggle is deliberately limited:

- if Shield is unavailable, we do not show another block of body text there
- if Shield's bot threshold is `0`, we show the same warning below the toggle that also appears in the tooltip

## Why The Disable Script Exists

Gravity Forms renders toggle inputs with its own field names, and a disabled control may not always be enough on its own to preserve the stored value cleanly across the UI flow.

There is a very small inline vanilla JavaScript helper that:

- finds the visible Shield controls by name
- disables checkbox/radio inputs
- works for both the global and per-form settings

This is only a UI safety layer. It does not change the stored value.

## Review Notes

The main code paths worth checking are:

1. Shield settings are inserted in the right places in the Gravity Forms settings UI.
2. Saving global settings works without the old validation error.
3. Unsaved forms inherit the global default.
4. Saved forms override the global default.
5. Existing spam decisions are respected before Shield does anything.
6. Missing or broken Shield behavior does not interrupt submissions.
7. Unavailable Shield disables the setting without changing the stored value.
8. Threshold `0` shows the warning in the tooltip and below the per-form toggle.

## Important Callouts

- This integration is intentionally conservative. Only a strict boolean `true` from Shield blocks anything.
- Existing spam state wins. We do not overwrite earlier spam decisions.
- Existing abort state wins. We do not override earlier draft-abort decisions.
- Missing form state means inherit, not off.
- First form save creates an explicit override because the UI is a binary toggle, not a tri-state inherit control.
- When Shield is temporarily unavailable, the setting is disabled in the UI but its stored value is preserved.
- The 'Learn More' link is a short-link that redirects to a generic page, but we'll update this closer to release with a specific page for Gravity Forms Zero Spam so that we can capture the most recent screenshots for the new help article.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Shield silentCAPTCHA into Gravity Forms Zero Spam.
  * Added global and per-form toggles, status indicators, help text, and inheritance-aware settings.
  * Uses Shield verdicts to mark submissions as spam, optionally abort draft saves, and add fallback notes when automatic spam marking isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->