### PR TITLE
Release 1.7.4

### DIFF
--- a/assets/js/token-injection.js
+++ b/assets/js/token-injection.js
@@ -32,11 +32,25 @@
 		body.append('action', 'gf_zero_spam_token');
 		body.append('form_id', cfg.formId);
 
-		return fetch(cfg.ajaxUrl, {
-			method: 'POST',
-			body: body,
-			signal: AbortSignal.timeout(cfg.timeout)
-		})
+		let response;
+
+		try {
+			response = fetch(cfg.ajaxUrl, {
+				method: 'POST',
+				body: body,
+				signal: AbortSignal.timeout(cfg.timeout)
+			});
+		} catch (err) {
+			log('Token fetch failed for form ' + cfg.formId + ': ' + err.message + '. Using fallback token.');
+			return Promise.resolve(cfg.fallbackToken);
+		}
+
+		if (!response || typeof response.then !== 'function') {
+			log('Token fetch failed for form ' + cfg.formId + ': fetch returned non-thenable. Using fallback token.');
+			return Promise.resolve(cfg.fallbackToken);
+		}
+
+		return response
 			.then((res) => {
 				if (!res.ok) {
 					throw new Error('AJAX ' + res.status);

--- a/assets/js/token-injection.js
+++ b/assets/js/token-injection.js
@@ -32,25 +32,13 @@
 		body.append('action', 'gf_zero_spam_token');
 		body.append('form_id', cfg.formId);
 
-		let response;
+		const options = { method: 'POST', body: body };
 
-		try {
-			response = fetch(cfg.ajaxUrl, {
-				method: 'POST',
-				body: body,
-				signal: AbortSignal.timeout(cfg.timeout)
-			});
-		} catch (err) {
-			log('Token fetch failed for form ' + cfg.formId + ': ' + err.message + '. Using fallback token.');
-			return Promise.resolve(cfg.fallbackToken);
+		if (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) {
+			options.signal = AbortSignal.timeout(cfg.timeout);
 		}
 
-		if (!response || typeof response.then !== 'function') {
-			log('Token fetch failed for form ' + cfg.formId + ': fetch returned non-thenable. Using fallback token.');
-			return Promise.resolve(cfg.fallbackToken);
-		}
-
-		return response
+		return fetch(cfg.ajaxUrl, options)
 			.then((res) => {
 				if (!res.ok) {
 					throw new Error('AJAX ' + res.status);

--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Gravity Forms Zero Spam
  * Plugin URI:        https://www.gravitykit.com?utm_source=plugin&utm_campaign=zero-spam&utm_content=pluginuri
  * Description:       Enhance Gravity Forms to include effective anti-spam measures—without using a CAPTCHA.
- * Version:           1.7.3
+ * Version:           1.7.4
  * Author:            GravityKit
  * Author URI:        https://www.gravitykit.com?utm_source=plugin&utm_campaign=zero-spam&utm_content=authoruri
  * Requires PHP:      7.4

--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -103,6 +103,9 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 
 		parent::init();
 
+		add_filter( 'gform_noconflict_scripts', [ $this, 'register_noconflict_scripts' ] );
+		add_filter( 'gform_noconflict_styles', [ $this, 'register_noconflict_styles' ] );
+
 		add_filter( 'gform_form_settings_fields', [ $this, 'add_settings_field' ], 10, 2 );
 		add_filter( 'gform_tooltips', [ $this, 'add_tooltip' ] );
 
@@ -184,6 +187,36 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 		$tooltips['enableGFZeroSpam'] = esc_html__( 'Enable to fight spam using a simple, effective method that is more effective than the built-in anti-spam honeypot.', 'gravity-forms-zero-spam' );
 
 		return $tooltips;
+	}
+
+	/**
+	 * Registers scripts with GF No Conflict mode.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $scripts Allowed script handles.
+	 *
+	 * @return array
+	 */
+	public function register_noconflict_scripts( $scripts ) {
+		$scripts[] = 'gf-zero-spam';
+
+		return $scripts;
+	}
+
+	/**
+	 * Registers styles with GF No Conflict mode.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $styles Allowed style handles.
+	 *
+	 * @return array
+	 */
+	public function register_noconflict_styles( $styles ) {
+		$styles[] = 'gf-zero-spam';
+
+		return $styles;
 	}
 
 	/**

--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -192,7 +192,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	/**
 	 * Registers scripts with GF No Conflict mode.
 	 *
-	 * @since TBD
+	 * @since 1.7.4
 	 *
 	 * @param array $scripts Allowed script handles.
 	 *
@@ -207,7 +207,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	/**
 	 * Registers styles with GF No Conflict mode.
 	 *
-	 * @since TBD
+	 * @since 1.7.4
 	 *
 	 * @param array $styles Allowed style handles.
 	 *
@@ -804,7 +804,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 * Falls back to the GF_ZERO_SPAM_TOKEN_TTL constant when no setting is saved
 	 * or the stored value is invalid (empty, zero, negative, or sub-hour).
 	 *
-	 * @since TBD
+	 * @since 1.7.4
 	 *
 	 * @return int Token TTL in seconds.
 	 */
@@ -826,7 +826,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 * The stored value is in seconds; on load it is reverse-converted to
 	 * the appropriate unit for display.
 	 *
-	 * @since TBD
+	 * @since 1.7.4
 	 *
 	 * @param array $field The field configuration array.
 	 *
@@ -932,7 +932,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	/**
 	 * Converts the token lifetime number and unit inputs to seconds for storage.
 	 *
-	 * @since TBD
+	 * @since 1.7.4
 	 *
 	 * @param array  $field The field configuration array.
 	 * @param string $value The raw value from the main field name (unused).
@@ -967,7 +967,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 * Ensures the value is a positive integer and within the allowed range
 	 * (minimum 1 hour, maximum 90 days equivalent).
 	 *
-	 * @since TBD
+	 * @since 1.7.4
 	 *
 	 * @param object $field The GF Settings Field object with a set_error() method.
 	 * @param string $value The raw value from the main field name (unused).

--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -260,7 +260,6 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 * @return array
 	 */
 	public function plugin_settings_fields() {
-
 		$spam_report_description = sprintf(
             '<h3 style="margin-top: 0">%s</h3><p>%s</p><p><strong>%s</strong></p><p>%s</p><hr style="margin: 1em 0;">',
 			esc_html__( 'Know when entries are flagged as spam.', 'gravity-forms-zero-spam' ),
@@ -314,6 +313,22 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 							],
 						],
 						'required'      => false,
+					],
+					[
+						'label'               => esc_html__( 'Anti-Spam Expiration', 'gravity-forms-zero-spam' ),
+						'type'                => 'token_lifetime',
+						'name'                => 'gf_zero_spam_token_lifetime',
+						'dependency'          => [
+							'live'   => true,
+							'fields' => [
+								[
+									'field'  => 'gf_zero_spam_blocking',
+									'values' => [ '1' ],
+								],
+							],
+						],
+						'save_callback'       => [ $this, 'save_token_lifetime' ],
+						'validation_callback' => [ $this, 'validate_token_lifetime' ],
 					],
 				],
 			],
@@ -781,6 +796,210 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 		$results = $this->get_latest_spam_entries();
 
 		return count( $results );
+	}
+
+	/**
+	 * Returns the configured token TTL in seconds.
+	 *
+	 * Falls back to the GF_ZERO_SPAM_TOKEN_TTL constant when no setting is saved
+	 * or the stored value is invalid (empty, zero, negative, or sub-hour).
+	 *
+	 * @since TBD
+	 *
+	 * @return int Token TTL in seconds.
+	 */
+	public function get_token_ttl_seconds(): int {
+		$seconds = $this->get_plugin_setting( 'gf_zero_spam_token_lifetime' );
+
+		// Fallback to constant for fresh installs or corrupted settings.
+		if ( null === $seconds || '' === $seconds || (int) $seconds < HOUR_IN_SECONDS ) {
+			return GF_ZERO_SPAM_TOKEN_TTL;
+		}
+
+		return (int) $seconds;
+	}
+
+	/**
+	 * Renders the token lifetime custom settings field.
+	 *
+	 * Outputs a number input and unit dropdown (hours/days) side-by-side.
+	 * The stored value is in seconds; on load it is reverse-converted to
+	 * the appropriate unit for display.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $field The field configuration array.
+	 *
+	 * @return void
+	 */
+	public function settings_token_lifetime( $field ) {
+		$name_prefix  = '_gaddon_setting_' . $field['name'];
+		$posted_value = rgpost( $name_prefix . '_value' );
+		$posted_unit  = rgpost( $name_prefix . '_unit' );
+
+		// On postback (validation error), preserve what the user typed.
+		if ( '' !== $posted_value ) {
+			$display_value = $posted_value;
+			$display_unit  = in_array( $posted_unit, [ 'hours', 'days' ], true ) ? $posted_unit : 'days';
+		} else {
+			$stored_seconds = (int) $this->get_setting( $field['name'], '' );
+
+			// Reverse-convert stored seconds to display value and unit.
+			if ( $stored_seconds > 0 && 0 === $stored_seconds % DAY_IN_SECONDS ) {
+				$display_value = $stored_seconds / DAY_IN_SECONDS;
+				$display_unit  = 'days';
+			} elseif ( $stored_seconds > 0 ) {
+				$display_value = (int) ceil( $stored_seconds / HOUR_IN_SECONDS );
+				$display_unit  = 'hours';
+			} else {
+				// Default display: 7 days.
+				$display_value = 7;
+				$display_unit  = 'days';
+			}
+		}
+
+		$value_id = esc_attr( '_gaddon_setting_' . $field['name'] . '_value' );
+		$unit_id  = esc_attr( '_gaddon_setting_' . $field['name'] . '_unit' );
+		?>
+		<span class="gform-settings-description" style="margin-bottom: 8px;">
+			<?php esc_html_e( 'How long a spam prevention token remains valid after a visitor loads your form. If form submissions are being incorrectly flagged as spam, try increasing this value. (Default: 7 days)', 'gravity-forms-zero-spam' ); ?>
+		</span>
+		<span style="display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+			<label for="<?php echo esc_attr( $value_id ); ?>" style="position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(1px,1px,1px,1px);">
+				<?php esc_html_e( 'Expiration length', 'gravity-forms-zero-spam' ); ?>
+			</label>
+			<input
+				type="number"
+				name="<?php echo esc_attr( $value_id ); ?>"
+				id="<?php echo esc_attr( $value_id ); ?>"
+				min="1"
+				style="display: inline-block; width: auto;"
+				value="<?php echo esc_attr( $display_value ); ?>"
+				class="small-text"
+			/>
+			<label for="<?php echo esc_attr( $unit_id ); ?>" style="position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(1px,1px,1px,1px);">
+				<?php esc_html_e( 'Expiration unit', 'gravity-forms-zero-spam' ); ?>
+			</label>
+			<select
+				name="<?php echo esc_attr( $unit_id ); ?>"
+				id="<?php echo esc_attr( $unit_id ); ?>"
+				style="display: inline-block; width: auto;"
+			>
+				<option value="hours" <?php selected( $display_unit, 'hours' ); ?>>
+					<?php esc_html_e( 'hours', 'gravity-forms-zero-spam' ); ?>
+				</option>
+				<option value="days" <?php selected( $display_unit, 'days' ); ?>>
+					<?php esc_html_e( 'days', 'gravity-forms-zero-spam' ); ?>
+				</option>
+			</select>
+		</span>
+		<?php
+		// Render validation error if the field object supports it.
+		if ( is_object( $field ) && method_exists( $field, 'get_error_icon' ) ) {
+			echo $field->get_error_icon(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- GF framework handles escaping.
+		}
+		?>
+		<div
+			id="gf-zero-spam-ttl-warning"
+			class="alert gforms_note_warning"
+			role="alert"
+			style="display: none; margin-top: 8px;"
+		>
+			<?php esc_html_e( 'Short expiration times may cause false positives on sites with page caching.', 'gravity-forms-zero-spam' ); ?>
+		</div>
+		<script>
+			( function() {
+				const valueInput = document.getElementById( '<?php echo esc_js( $value_id ); ?>' );
+				const unitSelect = document.getElementById( '<?php echo esc_js( $unit_id ); ?>' );
+				const warning    = document.getElementById( 'gf-zero-spam-ttl-warning' );
+
+				function checkWarning() {
+					const val     = parseInt( valueInput.value, 10 ) || 0;
+					const unit    = unitSelect.value;
+					const seconds = unit === 'days' ? val * 86400 : val * 3600;
+
+					warning.style.display = seconds > 0 && seconds < 86400 ? 'block' : 'none';
+				}
+
+				valueInput.addEventListener( 'input', checkWarning );
+				unitSelect.addEventListener( 'change', checkWarning );
+				checkWarning();
+			} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Converts the token lifetime number and unit inputs to seconds for storage.
+	 *
+	 * @since TBD
+	 *
+	 * @param array  $field The field configuration array.
+	 * @param string $value The raw value from the main field name (unused).
+	 *
+	 * @return int The token lifetime in seconds.
+	 */
+	public function save_token_lifetime( $field, $value ) {
+		$name_prefix = '_gaddon_setting_' . $field['name'];
+		$raw_value   = sanitize_text_field( rgpost( $name_prefix . '_value' ) );
+		$unit        = sanitize_text_field( rgpost( $name_prefix . '_unit' ) );
+
+		$numeric_value = (int) $raw_value;
+
+		if ( $numeric_value < 1 ) {
+			return GF_ZERO_SPAM_TOKEN_TTL;
+		}
+
+		if ( ! in_array( $unit, [ 'hours', 'days' ], true ) ) {
+			return GF_ZERO_SPAM_TOKEN_TTL;
+		}
+
+		if ( 'days' === $unit ) {
+			return $numeric_value * DAY_IN_SECONDS;
+		}
+
+		return $numeric_value * HOUR_IN_SECONDS;
+	}
+
+	/**
+	 * Validates the token lifetime inputs.
+	 *
+	 * Ensures the value is a positive integer and within the allowed range
+	 * (minimum 1 hour, maximum 90 days equivalent).
+	 *
+	 * @since TBD
+	 *
+	 * @param object $field The GF Settings Field object with a set_error() method.
+	 * @param string $value The raw value from the main field name (unused).
+	 *
+	 * @return void
+	 */
+	public function validate_token_lifetime( $field, $value ) {
+		$name_prefix = '_gaddon_setting_' . $field['name'];
+		$raw_value   = sanitize_text_field( rgpost( $name_prefix . '_value' ) );
+		$unit        = sanitize_text_field( rgpost( $name_prefix . '_unit' ) );
+
+		$numeric_value = (int) $raw_value;
+
+		if ( $numeric_value < 1 ) {
+			$field->set_error(
+				'days' === $unit
+					? esc_html__( 'Please enter at least 1 day.', 'gravity-forms-zero-spam' )
+					: esc_html__( 'Please enter at least 1 hour.', 'gravity-forms-zero-spam' )
+			);
+			return;
+		}
+
+		if ( ! in_array( $unit, [ 'hours', 'days' ], true ) ) {
+			$field->set_error( esc_html__( 'Please select hours or days.', 'gravity-forms-zero-spam' ) );
+			return;
+		}
+
+		if ( 'days' === $unit && $numeric_value > 90 ) {
+			$field->set_error( esc_html__( 'The maximum expiration is 90 days.', 'gravity-forms-zero-spam' ) );
+		} elseif ( 'hours' === $unit && $numeric_value > 2160 ) {
+			$field->set_error( esc_html__( 'The maximum expiration is 2160 hours (90 days).', 'gravity-forms-zero-spam' ) );
+		}
 	}
 
 	/**

--- a/includes/class-gf-zero-spam-token-endpoint.php
+++ b/includes/class-gf-zero-spam-token-endpoint.php
@@ -94,7 +94,7 @@ class GF_Zero_Spam_Token_Endpoint {
 		 *
 		 * @param int $ttl Token lifetime in seconds. Default 604800 (7 days).
 		 */
-		$ttl = (int) apply_filters( 'gf_zero_spam_token_ttl', GF_ZERO_SPAM_TOKEN_TTL );
+		$ttl = (int) apply_filters( 'gf_zero_spam_token_ttl', GF_Zero_Spam_AddOn::get_instance()->get_token_ttl_seconds() );
 
 		return [
 			'token'   => GF_Zero_Spam_Token::mint( $form_id, $ttl ),

--- a/includes/class-gf-zero-spam.php
+++ b/includes/class-gf-zero-spam.php
@@ -231,7 +231,7 @@ class GF_Zero_Spam {
 		 *
 		 * @param int $ttl Fallback token lifetime in seconds. Default 604800 (7 days).
 		 */
-		$fallback_ttl = (int) apply_filters( 'gf_zero_spam_fallback_token_ttl', GF_ZERO_SPAM_TOKEN_TTL );
+		$fallback_ttl = (int) apply_filters( 'gf_zero_spam_fallback_token_ttl', GF_Zero_Spam_AddOn::get_instance()->get_token_ttl_seconds() );
 
 		$this->pending_scripts[ $form_id ] = [
 			'ajaxUrl'       => esc_url_raw( admin_url( 'admin-ajax.php' ) ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gravity-forms-zero-spam",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "scripts": {
     "build:css": "postcss assets/css/email-rejection.pcss -o dist/css/gf-zero-spam.css --no-map",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gravityview
 Tags: gravity forms, spam, captcha, honeypot, anti-spam
 Requires at least: 4.7
 Tested up to: 6.9.4
-Stable tag: 1.7.3
+Stable tag: 1.7.4
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -110,7 +110,7 @@ You can enable a spam summary report email. This email will be sent to the email
 
 == Changelog ==
 
-= develop =
+= 1.7.4 on April 2, 2026 =
 
 * Added: "Anti-Spam Expiration" setting to control how long spam prevention tokens remain valid, accessible from Forms > Settings > Zero Spam
 * Fixed: Email rejection settings and form editor scripts not loading when Gravity Forms No Conflict mode is enabled

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ You can enable a spam summary report email. This email will be sent to the email
 
 = develop =
 
+* Added: "Anti-Spam Expiration" setting to control how long spam prevention tokens remain valid, accessible from Forms → Settings → Zero Spam
 * Fixed: Email rejection settings and form editor scripts not loading when Gravity Forms No Conflict mode is enabled
 
 = 1.7.3 on March 24, 2026 =

--- a/readme.txt
+++ b/readme.txt
@@ -112,8 +112,9 @@ You can enable a spam summary report email. This email will be sent to the email
 
 = develop =
 
-* Added: "Anti-Spam Expiration" setting to control how long spam prevention tokens remain valid, accessible from Forms → Settings → Zero Spam
+* Added: "Anti-Spam Expiration" setting to control how long spam prevention tokens remain valid, accessible from Forms > Settings > Zero Spam
 * Fixed: Email rejection settings and form editor scripts not loading when Gravity Forms No Conflict mode is enabled
+* Fixed: Form submission failure ("Cannot read properties of undefined") caused by the token fetch request failing unexpectedly
 
 = 1.7.3 on March 24, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,10 @@ You can enable a spam summary report email. This email will be sent to the email
 
 == Changelog ==
 
+= develop =
+
+* Fixed: Email rejection settings and form editor scripts not loading when Gravity Forms No Conflict mode is enabled
+
 = 1.7.3 on March 24, 2026 =
 
 * Improved: Extended token lifetime to 7 days and improved token fetching compatibility


### PR DESCRIPTION
* Added: "Anti-Spam Expiration" setting to control how long spam prevention tokens remain valid, accessible from Forms > Settings > Zero Spam
* Fixed: Email rejection settings and form editor scripts not loading when Gravity Forms No Conflict mode is enabled
* Fixed: Form submission failure ("Cannot read properties of undefined") caused by the token fetch request failing unexpectedly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Anti-Spam Expiration" setting to control spam-prevention token lifetime.

* **Bug Fixes**
  * Fixed form editor scripts and email rejection settings failing to load in No Conflict mode.
  * Fixed form submission failures caused by token fetch errors.
  * Improved token fetch error handling and compatibility to reduce unexpected failures.

* **Documentation**
  * Updated changelog/release notes for version 1.7.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/tjmgtw9rkovoxx0ipd62e/gravity-forms-zero-spam-1.7.4-5ab844b.zip?rlkey=uosd553e0ptn97pajbkia8lg8&dl=1) (5ab844b).