### PR TITLE
Release 1.7.5

### DIFF
--- a/assets/js/token-injection.js
+++ b/assets/js/token-injection.js
@@ -38,7 +38,21 @@
 			options.signal = AbortSignal.timeout(cfg.timeout);
 		}
 
-		return fetch(cfg.ajaxUrl, options)
+		let response;
+
+		try {
+			response = fetch(cfg.ajaxUrl, options);
+		} catch (err) {
+			log('Token fetch failed for form ' + cfg.formId + ': ' + err.message + '. Using fallback token.');
+			return Promise.resolve(cfg.fallbackToken);
+		}
+
+		if (!response || typeof response.then !== 'function') {
+			log('Token fetch failed for form ' + cfg.formId + ': fetch returned non-thenable. Using fallback token.');
+			return Promise.resolve(cfg.fallbackToken);
+		}
+
+		return response
 			.then((res) => {
 				if (!res.ok) {
 					throw new Error('AJAX ' + res.status);

--- a/assets/js/token-injection.js
+++ b/assets/js/token-injection.js
@@ -52,7 +52,7 @@
 			return Promise.resolve(cfg.fallbackToken);
 		}
 
-		return response
+		return Promise.resolve(response)
 			.then((res) => {
 				if (!res.ok) {
 					throw new Error('AJAX ' + res.status);

--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Gravity Forms Zero Spam
  * Plugin URI:        https://www.gravitykit.com?utm_source=plugin&utm_campaign=zero-spam&utm_content=pluginuri
  * Description:       Enhance Gravity Forms to include effective anti-spam measures—without using a CAPTCHA.
- * Version:           1.7.4
+ * Version:           1.7.5
  * Author:            GravityKit
  * Author URI:        https://www.gravitykit.com?utm_source=plugin&utm_campaign=zero-spam&utm_content=authoruri
  * Requires PHP:      7.4

--- a/includes/class-gf-zero-spam.php
+++ b/includes/class-gf-zero-spam.php
@@ -293,7 +293,7 @@ class GF_Zero_Spam {
 	 * built at print time, after all forms on the page (including those
 	 * rendered via wp_footer by themes and plugins) have been collected.
 	 *
-	 * @since TBD
+	 * @since 1.7.5
 	 *
 	 * @param string $tag    The script tag HTML.
 	 * @param string $handle The script handle.

--- a/includes/class-gf-zero-spam.php
+++ b/includes/class-gf-zero-spam.php
@@ -276,35 +276,45 @@ class GF_Zero_Spam {
 			true
 		);
 
-		// Output config in the footer so all forms have been collected.
-		add_action( 'wp_footer', [ $this, 'localize_config' ], 1 );
+		// Inject the config at print time via script_loader_tag rather than
+		// wp_localize_script in a wp_footer callback. This guarantees all forms
+		// have been collected because script_loader_tag fires during
+		// wp_print_footer_scripts (wp_footer priority 20), after themes and
+		// plugins that render forms via wp_footer at default priority.
+		add_filter( 'script_loader_tag', [ $this, 'inject_config' ], 10, 2 );
 
 		return $form_string;
 	}
 
 	/**
-	 * Passes the collected form configurations to the external script.
+	 * Injects the form configuration inline before the Zero Spam script tag.
 	 *
-	 * Runs in wp_footer so all forms on the page have been processed
-	 * by add_key_field() before the config is serialized.
+	 * Uses script_loader_tag instead of wp_localize_script so the config is
+	 * built at print time, after all forms on the page (including those
+	 * rendered via wp_footer by themes and plugins) have been collected.
 	 *
-	 * @since 1.7.3
+	 * @since TBD
 	 *
-	 * @return void
+	 * @param string $tag    The script tag HTML.
+	 * @param string $handle The script handle.
+	 *
+	 * @return string The (possibly modified) script tag HTML.
 	 */
-	public function localize_config() {
-		if ( empty( $this->pending_scripts ) ) {
-			return;
+	public function inject_config( $tag, $handle ) {
+		if ( 'gf-zero-spam' !== $handle || empty( $this->pending_scripts ) ) {
+			return $tag;
 		}
 
-		wp_localize_script(
-			'gf-zero-spam',
-			'gfZeroSpamConfig',
+		$config = wp_json_encode(
 			[
 				'forms' => array_values( $this->pending_scripts ),
 				'debug' => defined( 'WP_DEBUG' ) && WP_DEBUG,
 			]
 		);
+
+		$inline = sprintf( "<script type='text/javascript'>var gfZeroSpamConfig = %s;</script>\n", $config );
+
+		return $inline . $tag;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gravity-forms-zero-spam",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "private": true,
   "scripts": {
     "build:css": "postcss assets/css/email-rejection.pcss -o dist/css/gf-zero-spam.css --no-map",

--- a/readme.txt
+++ b/readme.txt
@@ -110,7 +110,7 @@ You can enable a spam summary report email. This email will be sent to the email
 
 == Changelog ==
 
-= develop =
+= 1.7.5 on April 9, 2026 =
 
 * Fixed: Forms rendered in modals or other elements output via `wp_footer` (e.g., site-wide popups, slide-ins) were missing the spam prevention token, causing legitimate submissions to be flagged as spam
 

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,10 @@ You can enable a spam summary report email. This email will be sent to the email
 
 == Changelog ==
 
+= develop =
+
+* Fixed: Forms rendered in modals or other elements output via `wp_footer` (e.g., site-wide popups, slide-ins) were missing the spam prevention token, causing legitimate submissions to be flagged as spam
+
 = 1.7.4 on April 2, 2026 =
 
 * Added: "Anti-Spam Expiration" setting to control how long spam prevention tokens remain valid, accessible from Forms > Settings > Zero Spam

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gravityview
 Tags: gravity forms, spam, captcha, honeypot, anti-spam
 Requires at least: 4.7
 Tested up to: 6.9.4
-Stable tag: 1.7.4
+Stable tag: 1.7.5
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
* Fixed: Forms rendered in modals or other elements output via `wp_footer` (e.g., site-wide popups, slide-ins) were missing the spam prevention token, causing legitimate submissions to be flagged as spam


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures spam-prevention token is injected for forms rendered in modals, popups, and other footer-rendered elements so legitimate submissions aren’t flagged.
  * Improved token retrieval error handling and reliable fallback to prevent missing tokens.

* **Refactor**
  * Updated how the plugin injects its frontend configuration so tokens are available at script render time.

* **Version Update**
  * Released version 1.7.5 (changelog updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/cnym4r2l5d1tefdh43hrh/gravity-forms-zero-spam-1.7.5-0a69b04.zip?rlkey=h0owu5tolbs9cwsmfu3i4y2ho&dl=1) (0a69b04).