### PR TITLE
[GFZSPAM-25] Add Shield silentCAPTCHA integration and spam check order settings

### DIFF
--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -59,6 +59,24 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	const REPORT_CRON_HOOK_NAME = 'gf_zero_spam_send_report';
 
 	/**
+	 * Default spam check order (cheapest to most expensive).
+	 *
+	 * @since TBD
+	 *
+	 * @var array<int, string>
+	 */
+	const DEFAULT_SPAM_CHECK_ORDER = [ 'token', 'shield', 'ai' ];
+
+	/**
+	 * Resolved spam check order for this request.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<int, string>|null
+	 */
+	private $spam_check_order;
+
+	/**
 	 * Email rejection settings instance.
 	 *
 	 * @since 1.5.0
@@ -170,6 +188,20 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 * @return array|mixed
 	 */
 	public function filter_gf_zero_spam_check_key_field( $check_key_field = true, $form = [] ) {
+		return $this->is_zero_spam_enabled_for_form( $form, $check_key_field );
+	}
+
+	/**
+	 * Returns the effective Zero Spam state for a form (per-form setting, else global default).
+	 *
+	 * @since TBD
+	 *
+	 * @param array $form               The form object.
+	 * @param mixed $enabled_by_default Value returned when neither setting is saved.
+	 *
+	 * @return bool|mixed Whether Zero Spam is enabled for the form.
+	 */
+	public function is_zero_spam_enabled_for_form( $form = [], $enabled_by_default = true ) {
 		// The setting has been set, but it's not enabled.
 		if ( isset( $form['enableGFZeroSpam'] ) && empty( $form['enableGFZeroSpam'] ) ) {
 			return false;
@@ -178,10 +210,114 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 		$enabled = $this->get_plugin_setting( 'gf_zero_spam_blocking' );
 
 		if ( is_null( $enabled ) ) {
-			return $check_key_field;
+			return $enabled_by_default;
 		}
 
 		return ! empty( $enabled );
+	}
+
+	/**
+	 * Returns the configured spam check order.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<int, string> Check slugs in run order.
+	 */
+	public function get_spam_check_order(): array {
+		if ( null !== $this->spam_check_order ) {
+			return $this->spam_check_order;
+		}
+
+		$order = [
+			$this->get_plugin_setting( 'gf_zero_spam_check_order_1' ),
+			$this->get_plugin_setting( 'gf_zero_spam_check_order_2' ),
+			$this->get_plugin_setting( 'gf_zero_spam_check_order_3' ),
+		];
+
+		if ( ! $this->is_valid_spam_check_order( $order ) ) {
+			$order = self::DEFAULT_SPAM_CHECK_ORDER;
+		}
+
+		/**
+		 * Filters the order in which the spam checks run during form submission.
+		 *
+		 * The order is resolved once per request when the first check registers its
+		 * gform_entry_is_spam callback, so add this filter before Gravity Forms loads.
+		 * Invalid values (missing, duplicate, or unknown slugs) are ignored.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $order The check slugs in run order. Must contain 'token', 'shield', and 'ai' exactly once each.
+		 */
+		$filtered = apply_filters( 'gf_zero_spam_check_order', $order );
+
+		if ( $this->is_valid_spam_check_order( $filtered ) ) {
+			$order = array_values( $filtered );
+		}
+
+		$this->spam_check_order = $order;
+
+		return $order;
+	}
+
+	/**
+	 * Returns the gform_entry_is_spam priority for a spam check.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $check Check slug: 'token', 'shield', or 'ai'.
+	 *
+	 * @return int Hook priority (12, 14, or 16).
+	 */
+	public function get_spam_check_priority( string $check ): int {
+		$position = array_search( $check, $this->get_spam_check_order(), true );
+
+		// Unknown slugs get the last slot rather than colliding with the first one.
+		if ( false === $position ) {
+			$position = count( self::DEFAULT_SPAM_CHECK_ORDER ) - 1;
+		}
+
+		return 12 + ( 2 * (int) $position );
+	}
+
+	/**
+	 * Returns whether later checks are skipped once a check flags a submission as spam.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether to stop after the first detection.
+	 */
+	public function should_stop_after_first_detection(): bool {
+		$stop = $this->get_plugin_setting( 'gf_zero_spam_stop_after_first_detection' );
+
+		if ( null === $stop ) {
+			return true;
+		}
+
+		return ! empty( $stop );
+	}
+
+	/**
+	 * Validates a spam check order candidate.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $order Order candidate.
+	 *
+	 * @return bool Whether the candidate is a permutation of the known check slugs.
+	 */
+	private function is_valid_spam_check_order( $order ): bool {
+		if ( ! is_array( $order ) || 3 !== count( $order ) ) {
+			return false;
+		}
+
+		foreach ( $order as $check ) {
+			if ( ! is_string( $check ) ) {
+				return false;
+			}
+		}
+
+		return ! array_diff( $order, self::DEFAULT_SPAM_CHECK_ORDER ) && ! array_diff( self::DEFAULT_SPAM_CHECK_ORDER, $order );
 	}
 
 	/**
@@ -214,7 +350,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 * @return array
 	 */
 	public function add_tooltip( $tooltips ) {
-		$tooltips['enableGFZeroSpam'] = esc_html__( 'Enable to fight spam using a simple, effective method that is more effective than the built-in anti-spam honeypot.', 'gravity-forms-zero-spam' );
+		$tooltips['enableGFZeroSpam'] = esc_html__( 'Enable to fight spam using a simple, effective method that is more effective than the built-in anti-spam honeypot.', 'gravity-forms-zero-spam' ) . ' ' . esc_html__( 'When Zero Spam is disabled in the global plugin settings, all spam checks are turned off for every form and this setting has no effect.', 'gravity-forms-zero-spam' );
 
 		return $tooltips;
 	}
@@ -366,6 +502,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 					],
 				],
 			],
+			$this->get_spam_check_order_section(),
 			[
 				'title'       => esc_html__( 'Spam Report Email', 'gravity-forms-zero-spam' ),
 				'description' => $spam_report_description,
@@ -532,6 +669,73 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	}
 
 	/**
+	 * Builds the Spam Check Order settings section.
+	 *
+	 * @since TBD
+	 *
+	 * @return array Section config.
+	 */
+	private function get_spam_check_order_section(): array {
+		$check_choices = [
+			[
+				'label' => esc_html__( 'Zero Spam token', 'gravity-forms-zero-spam' ),
+				'value' => 'token',
+			],
+			[
+				'label' => esc_html__( 'Shield silentCAPTCHA', 'gravity-forms-zero-spam' ),
+				'value' => 'shield',
+			],
+			[
+				'label' => esc_html__( 'AI Spam Review', 'gravity-forms-zero-spam' ),
+				'value' => 'ai',
+			],
+		];
+
+		$availability_notes = [];
+
+		if ( ! $this->shield_silent_captcha || ! $this->shield_silent_captcha->is_shield_available() ) {
+			$availability_notes[] = esc_html__( 'Shield Security is not active — this check is skipped.', 'gravity-forms-zero-spam' );
+		}
+
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$availability_notes[] = esc_html__( 'AI Spam Review is not configured — this check is skipped.', 'gravity-forms-zero-spam' );
+		}
+
+		$order_description = implode( ' ', $availability_notes );
+		$position_labels   = [
+			esc_html__( 'First check', 'gravity-forms-zero-spam' ),
+			esc_html__( 'Second check', 'gravity-forms-zero-spam' ),
+			esc_html__( 'Third check', 'gravity-forms-zero-spam' ),
+		];
+		$fields            = [];
+
+		foreach ( $position_labels as $index => $label ) {
+			$fields[] = [
+				'label'         => $label,
+				'type'          => 'select',
+				'name'          => 'gf_zero_spam_check_order_' . ( $index + 1 ),
+				'default_value' => self::DEFAULT_SPAM_CHECK_ORDER[ $index ],
+				'choices'       => $check_choices,
+				'description'   => $order_description,
+			];
+		}
+
+		$fields[] = [
+			'label'         => esc_html__( 'Stop after first detection', 'gravity-forms-zero-spam' ),
+			'type'          => 'toggle',
+			'name'          => 'gf_zero_spam_stop_after_first_detection',
+			'default_value' => '1',
+			'description'   => esc_html__( 'When enabled, remaining checks are skipped once a check flags a submission as spam. When disabled, every check still runs and records its verdict as an entry note; a flagged submission is never restored by a later check.', 'gravity-forms-zero-spam' ),
+		];
+
+		return [
+			'title'       => esc_html__( 'Spam Check Order', 'gravity-forms-zero-spam' ),
+			'description' => esc_html__( 'Controls the order in which the spam checks run during form submission. Unavailable checks keep their position and are skipped.', 'gravity-forms-zero-spam' ),
+			'fields'      => $fields,
+		];
+	}
+
+	/**
 	 * Overrides parent to inject rules JSON from hidden input.
 	 *
 	 * @since 1.5.0
@@ -548,7 +752,51 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 			$settings = $this->shield_silent_captcha->normalize_plugin_settings( $settings );
 		}
 
+		$settings = $this->normalize_spam_check_order_settings( $settings );
+
 		parent::update_plugin_settings( $settings );
+	}
+
+	/**
+	 * Normalizes the spam check order settings before save.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $settings The settings to save.
+	 *
+	 * @return array The normalized settings.
+	 */
+	private function normalize_spam_check_order_settings( $settings ) {
+		$keys    = [ 'gf_zero_spam_check_order_1', 'gf_zero_spam_check_order_2', 'gf_zero_spam_check_order_3' ];
+		$present = false;
+
+		foreach ( $keys as $key ) {
+			if ( array_key_exists( $key, $settings ) ) {
+				$present = true;
+				break;
+			}
+		}
+
+		if ( ! $present ) {
+			return $settings;
+		}
+
+		$order = [];
+
+		foreach ( $keys as $key ) {
+			$order[] = rgar( $settings, $key );
+		}
+
+		// Any duplicate or invalid combination falls back to the default order.
+		if ( ! $this->is_valid_spam_check_order( $order ) ) {
+			$order = self::DEFAULT_SPAM_CHECK_ORDER;
+		}
+
+		foreach ( $keys as $index => $key ) {
+			$settings[ $key ] = $order[ $index ];
+		}
+
+		return $settings;
 	}
 
 	/**

--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -78,8 +78,12 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 
 	/**
 	 * Shield silentCAPTCHA integration instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var GF_Zero_Spam_Shield_Silent_Captcha|null
 	 */
-	private ?GF_Zero_Spam_Shield_Silent_Captcha $shield_silent_captcha = null;
+	private $shield_silent_captcha;
 
 	/**
 	 * Gets the singleton instance.

--- a/includes/class-gf-zero-spam-addon.php
+++ b/includes/class-gf-zero-spam-addon.php
@@ -12,6 +12,7 @@ require_once GF_ZERO_SPAM_DIR . 'includes/class-email-rejection-settings.php';
 require_once GF_ZERO_SPAM_DIR . 'includes/class-email-rejection-field-settings.php';
 require_once GF_ZERO_SPAM_DIR . 'includes/class-gf-zero-spam-ai-review.php';
 require_once GF_ZERO_SPAM_DIR . 'includes/class-gf-zero-spam-ai-review-settings.php';
+require_once GF_ZERO_SPAM_DIR . 'includes/class-gf-zero-spam-shield-silent-captcha.php';
 
 /**
  * @since 1.2
@@ -76,6 +77,11 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	private $ai_review_settings;
 
 	/**
+	 * Shield silentCAPTCHA integration instance.
+	 */
+	private ?GF_Zero_Spam_Shield_Silent_Captcha $shield_silent_captcha = null;
+
+	/**
 	 * Gets the singleton instance.
 	 *
 	 * @since 1.5.0
@@ -117,6 +123,9 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 
 		$this->ai_review_settings = new GF_Zero_Spam_AI_Review_Settings( $this );
 		$this->ai_review_settings->init();
+
+		$this->shield_silent_captcha = new GF_Zero_Spam_Shield_Silent_Captcha( $this );
+		$this->shield_silent_captcha->init();
 
 		parent::init();
 
@@ -511,6 +520,10 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 			$sections = $this->email_rejection_settings->add_settings_section( $sections );
 		}
 
+		if ( $this->shield_silent_captcha ) {
+			$sections = $this->shield_silent_captcha->add_plugin_settings_fields( $sections );
+		}
+
 		return $sections;
 	}
 
@@ -526,6 +539,9 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	public function update_plugin_settings( $settings ) {
 		if ( $this->email_rejection_settings ) {
 			$settings = $this->email_rejection_settings->save_rules_from_post( $settings );
+		}
+		if ( $this->shield_silent_captcha ) {
+			$settings = $this->shield_silent_captcha->normalize_plugin_settings( $settings );
 		}
 
 		parent::update_plugin_settings( $settings );

--- a/includes/class-gf-zero-spam-ai-review.php
+++ b/includes/class-gf-zero-spam-ai-review.php
@@ -145,6 +145,15 @@ final class GF_Zero_Spam_AI_Review {
 	private static $rescue_notes = [];
 
 	/**
+	 * Request-local review verdicts for already-flagged entries waiting for a note.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<int, array{is_spam: bool, confidence: float}>
+	 */
+	private static $review_notes = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.9.0
@@ -167,7 +176,45 @@ final class GF_Zero_Spam_AI_Review {
 			return;
 		}
 
-		add_filter( 'gform_entry_is_spam', [ $this, 'maybe_mark_spam' ], 20, 3 );
+		add_filter( 'gform_entry_is_spam', [ $this, 'maybe_mark_spam' ], $this->addon->get_spam_check_priority( 'ai' ), 3 );
+
+		// Rescue must always see the final token verdict; when AI is not the last
+		// check in the order, defer rescue to a dedicated pass after all three slots.
+		if ( $this->is_rescue_deferred() ) {
+			add_filter( 'gform_entry_is_spam', [ $this, 'maybe_rescue_flagged_entry' ], 18, 3 );
+		}
+	}
+
+	/**
+	 * Determines whether rescue runs in a dedicated late callback instead of the main one.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether rescue is deferred.
+	 */
+	private function is_rescue_deferred() {
+		$order = $this->addon->get_spam_check_order();
+
+		return 'ai' !== end( $order );
+	}
+
+	/**
+	 * Rescue-only late pass for orders that place AI before the last check.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool  $is_spam Whether the entry is currently spam.
+	 * @param array $form    The form currently being processed.
+	 * @param array $entry   The entry currently being processed.
+	 *
+	 * @return bool The spam verdict.
+	 */
+	public function maybe_rescue_flagged_entry( $is_spam, $form = [], $entry = [] ) {
+		if ( ! $is_spam ) {
+			return $is_spam;
+		}
+
+		return $this->maybe_rescue( $is_spam, $form, $entry );
 	}
 
 	/**
@@ -183,7 +230,15 @@ final class GF_Zero_Spam_AI_Review {
 	 */
 	public function maybe_mark_spam( $is_spam = false, $form = [], $entry = [] ) {
 		if ( $is_spam ) {
-			return $this->maybe_rescue( $is_spam, $form, $entry );
+			if ( ! $this->is_rescue_deferred() ) {
+				$is_spam = $this->maybe_rescue( $is_spam, $form, $entry );
+			}
+
+			if ( $is_spam ) {
+				$this->maybe_review_already_flagged( $form, $entry );
+			}
+
+			return $is_spam;
 		}
 
 		if ( ! $this->is_submission_eligible( $form, $entry ) ) {
@@ -197,6 +252,110 @@ final class GF_Zero_Spam_AI_Review {
 		$result = $this->classify( $form, $entry );
 
 		return $this->apply_classification_result( $result, $is_spam, $form );
+	}
+
+	/**
+	 * Reviews an already-flagged submission and records the verdict when the stop setting is off.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $form  The form currently being processed.
+	 * @param array $entry The entry currently being processed.
+	 *
+	 * @return void
+	 */
+	private function maybe_review_already_flagged( $form, $entry ) {
+		if ( $this->addon->should_stop_after_first_detection() ) {
+			return;
+		}
+
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return;
+		}
+
+		if ( ! $this->is_submission_eligible( $form, $entry ) ) {
+			return;
+		}
+
+		$result = $this->classify( $form, $entry );
+
+		if ( empty( $result['verdict'] ) || ! is_array( $result['verdict'] ) ) {
+			return;
+		}
+
+		$this->schedule_review_note( $form, $result['verdict'] );
+	}
+
+	/**
+	 * Schedules an entry note recording the AI verdict for an already-flagged entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $form    The form currently being processed.
+	 * @param array $verdict The normalized AI verdict.
+	 *
+	 * @return void
+	 */
+	private function schedule_review_note( $form, $verdict ) {
+		$form_id = $this->get_form_id( $form );
+
+		if ( $form_id < 1 ) {
+			return;
+		}
+
+		self::$review_notes[ $form_id ] = [
+			'is_spam'    => ! empty( $verdict['is_spam'] ),
+			'confidence' => (float) $verdict['confidence'],
+		];
+
+		add_action( 'gform_entry_created', [ $this, 'add_review_verdict_note' ], 20, 2 );
+	}
+
+	/**
+	 * Adds the scheduled AI verdict note to the created entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $entry The created entry.
+	 * @param array $form  The submitted form.
+	 *
+	 * @return void
+	 */
+	public function add_review_verdict_note( $entry, $form ) {
+		$form_id = $this->get_form_id( $form );
+
+		if ( empty( self::$review_notes[ $form_id ] ) ) {
+			return;
+		}
+
+		$context = self::$review_notes[ $form_id ];
+		unset( self::$review_notes[ $form_id ] );
+
+		if ( empty( self::$review_notes ) ) {
+			remove_action( 'gform_entry_created', [ $this, 'add_review_verdict_note' ], 20 );
+		}
+
+		$entry_id = (int) rgar( $entry, 'id' );
+
+		if ( $entry_id < 1 ) {
+			return;
+		}
+
+		if ( $context['is_spam'] ) {
+			$note = strtr(
+				/* translators: placeholders in [brackets] are replaced and must not be translated. */
+				__( 'AI review also classified this submission as spam (confidence [confidence]).', 'gravity-forms-zero-spam' ),
+				[ '[confidence]' => $this->format_log_number( $context['confidence'] ) ]
+			);
+		} else {
+			$note = strtr(
+				/* translators: placeholders in [brackets] are replaced and must not be translated. */
+				__( 'AI review classified this submission as legitimate (confidence [confidence]).', 'gravity-forms-zero-spam' ),
+				[ '[confidence]' => $this->format_log_number( $context['confidence'] ) ]
+			);
+		}
+
+		GFAPI::add_note( $entry_id, 0, self::SPAM_FILTER_NAME, sanitize_text_field( $note ) );
 	}
 
 	/**

--- a/includes/class-gf-zero-spam-ai-review.php
+++ b/includes/class-gf-zero-spam-ai-review.php
@@ -283,29 +283,30 @@ final class GF_Zero_Spam_AI_Review {
 			return;
 		}
 
-		$this->schedule_review_note( $form, $result['verdict'] );
+		$this->schedule_review_note( $form, $result );
 	}
 
 	/**
-	 * Schedules an entry note recording the AI verdict for an already-flagged entry.
+	 * Schedules an entry note recording the AI decision for an already-flagged entry.
 	 *
 	 * @since TBD
 	 *
-	 * @param array $form    The form currently being processed.
-	 * @param array $verdict The normalized AI verdict.
+	 * @param array $form   The form currently being processed.
+	 * @param array $result Classification result with the final is_spam decision.
 	 *
 	 * @return void
 	 */
-	private function schedule_review_note( $form, $verdict ) {
+	private function schedule_review_note( $form, $result ) {
 		$form_id = $this->get_form_id( $form );
 
 		if ( $form_id < 1 ) {
 			return;
 		}
 
+		// Record the final decision (threshold + gf_zero_spam_ai_result applied), not the raw model verdict.
 		self::$review_notes[ $form_id ] = [
-			'is_spam'    => ! empty( $verdict['is_spam'] ),
-			'confidence' => (float) $verdict['confidence'],
+			'is_spam'    => ! empty( $result['is_spam'] ),
+			'confidence' => (float) $result['verdict']['confidence'],
 		];
 
 		add_action( 'gform_entry_created', [ $this, 'add_review_verdict_note' ], 20, 2 );

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -1,0 +1,768 @@
+<?php
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Shield silentCAPTCHA integration for Gravity Forms Zero Spam.
+ */
+class GF_Zero_Spam_Shield_Silent_Captcha {
+
+	private const SETTING_KEY      = 'shield_silent_captcha';
+	private const PERSIST_KEY      = 'shield_silent_captcha_persist';
+	private const STATUS_FIELD_KEY = 'shield_silent_captcha_status';
+	private const HELP_URL         = 'https://clk.shldscrty.com/gravityformszerospamsilentcaptcha';
+	private const SPAM_FILTER_NAME = 'Shield silentCAPTCHA';
+
+	/**
+	 * Add-on instance.
+	 */
+	private GF_Zero_Spam_AddOn $addon;
+
+	/**
+	 * Cached Shield availability after plugins_loaded.
+	 */
+	private ?bool $shield_available = null;
+
+	/**
+	 * Cached threshold-zero state after plugins_loaded.
+	 */
+	private ?bool $shield_threshold_zero = null;
+
+	/**
+	 * Shield-flagged form IDs used for the entry-note fallback path.
+	 *
+	 * @var array<int, bool>
+	 */
+	private array $flagged_forms = [];
+
+	public function __construct( GF_Zero_Spam_AddOn $addon ) {
+		$this->addon = $addon;
+	}
+
+	/**
+	 * Registers Shield hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'gform_form_settings_fields', [ $this, 'add_form_settings_fields' ], 11, 2 );
+		add_filter( 'gform_form_settings_before_save', [ $this, 'normalize_form_settings' ] );
+		add_filter( 'gform_tooltips', [ $this, 'add_tooltips' ] );
+		add_filter( 'gform_entry_is_spam', [ $this, 'filter_entry_is_spam' ], 20, 3 );
+		add_filter( 'gform_abort_submission_with_confirmation', [ $this, 'maybe_abort_submission' ], 30, 2 );
+		add_action( 'gform_entry_created', [ $this, 'maybe_add_entry_note' ] );
+	}
+
+	/**
+	 * Adds Shield fields to the existing Spam Blocking plugin settings section.
+	 *
+	 * @param array $sections Settings sections.
+	 *
+	 * @return array
+	 */
+	public function add_plugin_settings_fields( $sections ) {
+		$shield_fields = $this->get_plugin_settings_fields();
+
+		foreach ( $sections as &$section ) {
+			if ( ! isset( $section['fields'] ) || ! is_array( $section['fields'] ) ) {
+				continue;
+			}
+
+			if ( ! $this->section_contains_field( $section, 'gf_zero_spam_blocking' ) ) {
+				continue;
+			}
+
+			$section['fields'] = $this->insert_fields_after_name( $section['fields'], 'gf_zero_spam_blocking', $shield_fields );
+			break;
+		}
+
+		return $sections;
+	}
+
+	/**
+	 * Normalizes Shield plugin settings before save.
+	 *
+	 * @param array $settings Settings array.
+	 *
+	 * @return array
+	 */
+	public function normalize_plugin_settings( $settings ) {
+		$submitted = $settings[ self::SETTING_KEY ] ?? null;
+		$persisted = rgar( $settings, self::PERSIST_KEY );
+
+		if ( null === $persisted ) {
+			$persisted = rgpost( '_gform_setting_' . self::PERSIST_KEY );
+		}
+
+		$settings[ self::SETTING_KEY ] = $this->resolve_setting_value_for_save(
+			$submitted,
+			$persisted,
+			$this->get_plugin_setting_value()
+		);
+
+		unset( $settings[ self::PERSIST_KEY ], $settings[ self::STATUS_FIELD_KEY ] );
+
+		return $settings;
+	}
+
+	/**
+	 * Adds Shield per-form fields after the existing Zero Spam toggle.
+	 *
+	 * @param array $fields Settings sections.
+	 * @param array $form   Current form object.
+	 *
+	 * @return array
+	 */
+	public function add_form_settings_fields( $fields, $form ) {
+		$section_key = isset( $fields['spam'] ) ? 'spam' : 'form_options';
+
+		if ( ! isset( $fields[ $section_key ]['fields'] ) || ! is_array( $fields[ $section_key ]['fields'] ) ) {
+			return $fields;
+		}
+
+		$fields[ $section_key ]['fields'] = $this->insert_fields_after_name(
+			$fields[ $section_key ]['fields'],
+			'enableGFZeroSpam',
+			$this->get_form_settings_fields( $form )
+		);
+
+		return $fields;
+	}
+
+	/**
+	 * Normalizes Shield form settings before save.
+	 *
+	 * @param array $form Form object.
+	 *
+	 * @return array
+	 */
+	public function normalize_form_settings( $form ) {
+		$submitted = rgpost( self::SETTING_KEY );
+		$persisted  = rgpost( self::PERSIST_KEY );
+
+		$form[ self::SETTING_KEY ] = $this->resolve_setting_value_for_save(
+			$submitted,
+			$persisted,
+			$this->get_effective_form_setting_value( $form )
+		);
+
+		unset( $form[ self::PERSIST_KEY ], $form[ self::STATUS_FIELD_KEY ] );
+
+		return $form;
+	}
+
+	/**
+	 * Adds the Shield form-settings tooltip.
+	 *
+	 * @param array $tooltips Existing tooltips.
+	 *
+	 * @return array
+	 */
+	public function add_tooltips( $tooltips ) {
+		if ( is_array( $tooltips ) ) {
+			$tooltips[ self::SETTING_KEY ] = esc_html( $this->get_form_tooltip_text( $this->addon->get_current_form() ) );
+		}
+
+		return $tooltips;
+	}
+
+	/**
+	 * Flags the entry as spam when Shield returns a strict true verdict.
+	 *
+	 * @param bool  $is_spam Existing spam state.
+	 * @param array $form    Form object.
+	 * @param array $entry   Entry object.
+	 *
+	 * @return bool
+	 */
+	public function filter_entry_is_spam( $is_spam, $form, $entry ) {
+		if ( $is_spam ) {
+			return $is_spam;
+		}
+
+		if ( GFCommon::current_user_can_any( 'gravityforms_edit_entries' ) ) {
+			return false;
+		}
+
+		if ( ! $this->is_submission_context_supported( $form, $entry ) ) {
+			return $is_spam;
+		}
+
+		if ( ! $this->is_shield_enabled_for_form( $form ) ) {
+			return $is_spam;
+		}
+
+		if ( true !== $this->resolve_shield_bot_verdict() ) {
+			return $is_spam;
+		}
+
+		$form_id = (int) rgar( $form, 'id' );
+
+		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
+			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf(__( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), 'Shield silentCAPTCHA' ) );
+		} else {
+			$this->flagged_forms[ $form_id ] = true;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Aborts Save and Continue draft creation when Shield returns a strict true verdict.
+	 *
+	 * @param bool  $do_abort Existing abort state.
+	 * @param array $form     Form object.
+	 *
+	 * @return bool
+	 */
+	public function maybe_abort_submission( $do_abort, $form ) {
+		if ( $do_abort || GFCommon::current_user_can_any( 'gravityforms_edit_entries' ) ) {
+			return $do_abort;
+		}
+
+		if ( ! rgpost( 'gform_save' ) || GFCommon::is_preview() ) {
+			return false;
+		}
+
+		if ( ! $this->is_shield_enabled_for_form( $form ) ) {
+			return false;
+		}
+
+		return true === $this->resolve_shield_bot_verdict();
+	}
+
+	/**
+	 * Adds a fallback entry note when GFCommon::set_spam_filter() is unavailable.
+	 *
+	 * @param array $entry Entry object.
+	 *
+	 * @return void
+	 */
+	public function maybe_add_entry_note( $entry ) {
+		$form_id = (int) rgar( $entry, 'form_id' );
+
+		if ( 'spam' !== rgar( $entry, 'status' ) || empty( $this->flagged_forms[ $form_id ] ) ) {
+			return;
+		}
+
+		if ( ! method_exists( 'GFAPI', 'add_note' ) ) {
+			return;
+		}
+
+		GFAPI::add_note(
+			$entry['id'],
+			0,
+			self::SPAM_FILTER_NAME,
+			__( 'This entry has been marked as spam by Shield silentCAPTCHA.', 'gravity-forms-zero-spam' ),
+			'gf-zero-spam',
+			'warning'
+		);
+
+		unset( $this->flagged_forms[ $form_id ] );
+	}
+
+	/**
+	 * Renders the plugin-settings status/help field.
+	 *
+	 * @param array $field Field config.
+	 * @param bool  $echo  Whether to echo markup.
+	 */
+	public function render_plugin_status_field( $field, $echo = true ): ?string {
+		$html = $this->render_plugin_status_message();
+
+		if ( ! $this->is_shield_available() ) {
+			$html .= $this->render_disable_control_script( [ '_gform_setting_' . self::SETTING_KEY, self::SETTING_KEY ] );
+		}
+
+		if ( $echo ) {
+			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is escaped at source.
+
+			return null;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Renders the hidden form-settings field used only for the disable-script fallback.
+	 *
+	 * @param array $field Field config.
+	 * @param bool  $echo  Whether to echo markup.
+	 */
+	public function render_form_status_field( $field, $echo = true ): ?string {
+		$html = '';
+
+		if ( ! $this->is_shield_available() ) {
+			$html = $this->render_disable_control_script( [ '_gform_setting_' . self::SETTING_KEY, self::SETTING_KEY ] );
+		} elseif ( $this->is_threshold_zero() ) {
+			$html = sprintf(
+				'<p class="description" style="color:#996800;">%s</p>',
+				esc_html( $this->get_form_tooltip_text( $this->addon->get_current_form() ) )
+			);
+		}
+
+		if ( $echo ) {
+			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is escaped at source.
+
+			return null;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Builds the Shield plugin settings field definitions.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_plugin_settings_fields(): array {
+		return [
+			[
+				'label'         => esc_html__( 'Enable Shield silentCAPTCHA by Default', 'gravity-forms-zero-spam' ),
+				'type'          => 'toggle',
+				'name'          => self::SETTING_KEY,
+				'default_value' => $this->get_plugin_setting_value(),
+				'disabled'      => ! $this->is_shield_available(),
+			],
+			[
+				'type'          => 'hidden',
+				'name'          => self::PERSIST_KEY,
+				'default_value' => $this->get_plugin_setting_value(),
+			],
+			[
+				'type'     => 'html',
+				'name'     => self::STATUS_FIELD_KEY,
+				'label'    => '',
+				'callback' => [ $this, 'render_plugin_status_field' ],
+			],
+		];
+	}
+
+	/**
+	 * Builds the Shield form settings field definitions.
+	 *
+	 * @param array $form Form object.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_form_settings_fields( $form ): array {
+		$current_value = $this->get_effective_form_setting_value( $form );
+
+		return [
+			[
+				'name'          => self::SETTING_KEY,
+				'type'          => 'toggle',
+				'label'         => esc_html__( 'Enable Shield silentCAPTCHA for this form', 'gravity-forms-zero-spam' ),
+				'tooltip'       => gform_tooltip( self::SETTING_KEY, '', true ),
+				'default_value' => $current_value,
+				'disabled'      => ! $this->is_shield_available(),
+			],
+			[
+				'type'          => 'hidden',
+				'name'          => self::PERSIST_KEY,
+				'default_value' => $current_value,
+			],
+			[
+				'hidden'   => ! $this->is_threshold_zero(),
+				'type'     => 'html',
+				'name'     => self::STATUS_FIELD_KEY,
+				'label'    => '',
+				'callback' => [ $this, 'render_form_status_field' ],
+			],
+		];
+	}
+
+	/**
+	 * Returns the stored global Shield setting in normalized string form.
+	 */
+	private function get_plugin_setting_value(): string {
+		return $this->normalize_setting_value( $this->addon->get_plugin_setting( self::SETTING_KEY ) );
+	}
+
+	/**
+	 * Determines whether the form has a saved Shield setting.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function has_saved_form_setting( $form ): bool {
+		return is_array( $form ) && array_key_exists( self::SETTING_KEY, $form );
+	}
+
+	/**
+	 * Returns the saved per-form Shield setting when present.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function get_saved_form_setting_value( $form ): ?string {
+		if ( ! $this->has_saved_form_setting( $form ) ) {
+			return null;
+		}
+
+		return $this->normalize_setting_value( $form[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Returns the effective Shield setting for the form.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function get_effective_form_setting_value( $form ): string {
+		$saved_value = $this->get_saved_form_setting_value( $form );
+
+		return null !== $saved_value ? $saved_value : $this->get_plugin_setting_value();
+	}
+
+	/**
+	 * Determines if Shield is enabled for the current form.
+	 *
+	 * @param array $form Form object.
+	 */
+	private function is_shield_enabled_for_form( $form ): bool {
+		return '1' === $this->get_effective_form_setting_value( $form );
+	}
+
+	/**
+	 * Normalizes a stored toggle value into the committed string shape.
+	 *
+	 * @param mixed $value Raw value.
+	 */
+	private function normalize_setting_value( $value ): string {
+		return in_array( (string) $value, [ '1', 'true', 'on', 'yes' ], true ) ? '1' : '0';
+	}
+
+	/**
+	 * Resolves the stored Shield setting value during a save operation.
+	 *
+	 * @param mixed  $submitted     Submitted toggle value, if present.
+	 * @param mixed  $persisted     Hidden persisted value, if present.
+	 * @param string $current_value Current stored normalized value.
+	 */
+	private function resolve_setting_value_for_save( $submitted, $persisted, string $current_value ): string {
+		if ( null !== $submitted ) {
+			return $this->normalize_setting_value( $submitted );
+		}
+
+		if ( ! $this->is_shield_available() ) {
+			if ( null !== $persisted ) {
+				return $this->normalize_setting_value( $persisted );
+			}
+
+			return $current_value;
+		}
+
+		return '0';
+	}
+
+	/**
+	 * Determines if the current request is a supported submission context.
+	 *
+	 * @param array $form  Form object.
+	 * @param array $entry Entry object.
+	 */
+	private function is_submission_context_supported( $form, $entry ): bool {
+		if ( GFCommon::is_preview() ) {
+			return false;
+		}
+
+		$supports_context = method_exists( 'GFFormDisplay', 'get_submission_context' );
+		if ( $supports_context && GFFormDisplay::get_submission_context() !== 'form-submit' ) {
+			return false;
+		}
+
+		if ( ! $supports_context && ! did_action( 'gform_pre_submission' ) ) {
+			return false;
+		}
+
+		return !( isset( $entry['user_agent'] ) && 'API' === $entry['user_agent'] );
+	}
+
+	/**
+	 * Resolves the Shield verdict using the documented callable order.
+	 */
+	private function resolve_shield_bot_verdict(): ?bool {
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			return null;
+		}
+
+		foreach ( $this->get_shield_callables() as $callable ) {
+			if ( ! is_callable( $callable ) ) {
+				continue;
+			}
+
+			try {
+				$verdict = call_user_func( $callable );
+			} catch ( \Throwable $e ) {
+				continue;
+			}
+
+			$normalized = $this->normalize_verdict( $verdict );
+			if ( null !== $normalized ) {
+				return $normalized;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determines if Shield is available for the current request.
+	 */
+	private function is_shield_available(): bool {
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			return false;
+		}
+
+		if ( null !== $this->shield_available ) {
+			return $this->shield_available;
+		}
+
+		$this->shield_available = false;
+
+		foreach ( $this->get_shield_callables() as $callable ) {
+			if ( is_callable( $callable ) ) {
+				$this->shield_available = true;
+				break;
+			}
+		}
+
+		return $this->shield_available;
+	}
+
+	/**
+	 * Determines if Shield is available and the threshold is zero.
+	 */
+	private function is_threshold_zero(): bool {
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			return false;
+		}
+
+		if ( null !== $this->shield_threshold_zero ) {
+			return $this->shield_threshold_zero;
+		}
+
+		$this->shield_threshold_zero = false;
+
+		if ( ! $this->is_shield_available() ) {
+			return $this->shield_threshold_zero;
+		}
+
+		foreach ( $this->get_shield_threshold_callables() as $callable ) {
+			if ( ! is_callable( $callable ) ) {
+				continue;
+			}
+
+			try {
+				$threshold = call_user_func( $callable );
+			} catch ( \Throwable $e ) {
+				continue;
+			}
+
+			if ( ! is_numeric( $threshold ) ) {
+				continue;
+			}
+
+			$this->shield_threshold_zero = 0 === (int) $threshold;
+			break;
+		}
+
+		return $this->shield_threshold_zero;
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	private function get_shield_callables(): array {
+		return [
+			'\\FernleafSystems\\Wordpress\\Plugin\\Shield\\Functions\\test_ip_is_bot',
+			'shield_test_ip_is_bot',
+		];
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	private function get_shield_threshold_callables(): array {
+		return [
+			'\\FernleafSystems\\Wordpress\\Plugin\\Shield\\Functions\\get_silentcaptcha_bot_threshold',
+			'shield_get_silentcaptcha_bot_threshold',
+		];
+	}
+
+	/**
+	 * Normalizes the Shield verdict into a strict tri-state.
+	 *
+	 * @param mixed $verdict Raw verdict.
+	 */
+	private function normalize_verdict( $verdict ): ?bool {
+		if ( true === $verdict ) {
+			return true;
+		}
+
+		if ( false === $verdict ) {
+			return false;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the form tooltip text for the current Shield state.
+	 */
+	private function get_form_tooltip_text( $form ): string {
+		$setting_scope = $this->get_form_setting_scope_text( $form );
+
+		if ( ! $this->is_shield_available() ) {
+			return $setting_scope . ' ' . $this->get_unavailable_message();
+		}
+
+		if ( $this->is_threshold_zero() ) {
+			return $setting_scope . ' ' . $this->get_threshold_zero_message();
+		}
+
+		return $setting_scope . ' ' . $this->get_form_help_text();
+	}
+
+	/**
+	 * Returns the plugin-settings status text for the current Shield state.
+	 */
+	private function get_plugin_status_text(): string {
+		if ( ! $this->is_shield_available() ) {
+			return $this->get_unavailable_message();
+		}
+
+		if ( $this->is_threshold_zero() ) {
+			return $this->get_threshold_zero_message();
+		}
+
+		return $this->get_global_help_text();
+	}
+
+	/**
+	 * Renders the plugin-settings status message with the Learn More link.
+	 */
+	private function render_plugin_status_message(): string {
+		$style = $this->is_shield_available() && $this->is_threshold_zero()
+			? ' style="color:#996800;"'
+			: '';
+
+		return sprintf(
+			'<p class="description"%s>%s <a href="%s" target="_blank" rel="noopener noreferrer">%s</a></p>',
+			$style,
+			esc_html( $this->get_plugin_status_text() ),
+			esc_url( self::HELP_URL ),
+			esc_html__( 'Learn More', 'gravity-forms-zero-spam' )
+		);
+	}
+
+	/**
+	 * Creates a tiny inline script to disable the visible Shield toggle.
+	 *
+	 * @param array<int, string> $field_names Candidate field names.
+	 */
+	private function render_disable_control_script( $field_names ): string {
+		$field_names_json = wp_json_encode( array_values( $field_names ) );
+
+		return <<<HTML
+<script>
+(function() {
+	'use strict';
+
+	const names = {$field_names_json};
+
+	function disableByName() {
+		for ( let i = 0; i < names.length; i++ ) {
+			const inputs = document.getElementsByName( names[i] );
+
+			for ( let j = 0; j < inputs.length; j++ ) {
+				if ( 'checkbox' === inputs[j].type || 'radio' === inputs[j].type ) {
+					inputs[j].disabled = true;
+				}
+			}
+		}
+	}
+
+	if ( 'loading' === document.readyState ) {
+		document.addEventListener( 'DOMContentLoaded', disableByName );
+		return;
+	}
+
+	disableByName();
+})();
+</script>
+HTML;
+	}
+
+	/**
+	 * Determines whether the section contains a given field name.
+	 *
+	 * @param array  $section    Section config.
+	 * @param string $field_name Field name.
+	 */
+	private function section_contains_field( $section, $field_name ): bool {
+		foreach ( $section['fields'] as $field ) {
+			if ( rgar( $field, 'name' ) === $field_name ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Inserts fields immediately after a named field, appending if not found.
+	 *
+	 * @param array  $fields     Existing fields.
+	 * @param string $field_name Target field name.
+	 * @param array  $new_fields Fields to insert.
+	 */
+	private function insert_fields_after_name( $fields, $field_name, $new_fields ): array {
+		$updated  = [];
+		$inserted = false;
+
+		foreach ( $fields as $field ) {
+			$updated[] = $field;
+
+			if ( rgar( $field, 'name' ) === $field_name ) {
+				foreach ( $new_fields as $new_field ) {
+					$updated[] = $new_field;
+				}
+
+				$inserted = true;
+			}
+		}
+
+		if ( ! $inserted ) {
+			foreach ( $new_fields as $new_field ) {
+				$updated[] = $new_field;
+			}
+		}
+
+		return $updated;
+	}
+
+	private function get_form_setting_scope_text( $form ): string {
+		if ( $this->has_saved_form_setting( $form ) ) {
+			return __( 'This setting is currently overriding the global default setting.', 'gravity-forms-zero-spam' );
+		}
+
+		return __( 'This setting is currently inheriting the global default setting.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_form_help_text(): string {
+		return __( 'Runs Shield silentCAPTCHA server-side for this form. No field needs to be added to the form.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_global_help_text(): string {
+		return __( 'Enable Shield silentCAPTCHA by default for forms. No field needs to be added to the form. Forms without their own Shield setting will use this default.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_unavailable_message(): string {
+		return __( 'Shield silentCAPTCHA is currently unavailable because Shield Security is not installed or active. This setting is disabled until Shield becomes available again.', 'gravity-forms-zero-spam' );
+	}
+
+	private function get_threshold_zero_message(): string {
+		return __( 'Shield silentCAPTCHA is available, but Shield\'s bot threshold is 0, so it will not flag submissions until that threshold is increased.', 'gravity-forms-zero-spam' );
+	}
+}

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -48,7 +48,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 */
 	public function init() {
 		add_filter( 'gform_form_settings_fields', [ $this, 'add_form_settings_fields' ], 11, 2 );
-		add_filter( 'gform_form_settings_before_save', [ $this, 'normalize_form_settings' ] );
+		add_filter( 'gform_pre_form_settings_save', [ $this, 'normalize_form_settings' ] );
 		add_filter( 'gform_tooltips', [ $this, 'add_tooltips' ] );
 		add_filter( 'gform_entry_is_spam', [ $this, 'filter_entry_is_spam' ], 20, 3 );
 		add_filter( 'gform_abort_submission_with_confirmation', [ $this, 'maybe_abort_submission' ], 30, 2 );
@@ -139,14 +139,18 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * @return array
 	 */
 	public function normalize_form_settings( $form ) {
-		$submitted = rgpost( self::SETTING_KEY );
-		$persisted  = rgpost( self::PERSIST_KEY );
+		$submitted         = rgpost( '_gform_setting_' . self::SETTING_KEY );
+		$persisted         = rgpost( '_gform_setting_' . self::PERSIST_KEY );
+		$had_saved_setting = $this->has_saved_form_setting( $form );
+		$current_value     = $this->get_effective_form_setting_value( $form );
+		$resolved          = $this->resolve_setting_value_for_save( $submitted, $persisted, $current_value );
 
-		$form[ self::SETTING_KEY ] = $this->resolve_setting_value_for_save(
-			$submitted,
-			$persisted,
-			$this->get_effective_form_setting_value( $form )
-		);
+		// Keep missing-key inheritance intact unless the form already had an override or the user changed the value.
+		if ( ! $had_saved_setting && $resolved === $current_value ) {
+			unset( $form[ self::SETTING_KEY ] );
+		} else {
+			$form[ self::SETTING_KEY ] = $resolved;
+		}
 
 		unset( $form[ self::PERSIST_KEY ], $form[ self::STATUS_FIELD_KEY ] );
 
@@ -286,7 +290,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	}
 
 	/**
-	 * Renders the hidden form-settings field used only for the disable-script fallback.
+	 * Renders the form-settings status field.
+	 *
+	 * Emits the disable-script fallback when Shield is unavailable and the inline
+	 * threshold warning when Shield is available but its bot threshold is zero.
 	 *
 	 * @param array $field Field config.
 	 * @param bool  $echo  Whether to echo markup.

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -57,12 +57,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Adds Shield fields to the existing Spam Blocking plugin settings section.
-	 *
-	 * @param array $sections Settings sections.
-	 *
-	 * @return array
 	 */
-	public function add_plugin_settings_fields( $sections ) {
+	public function add_plugin_settings_fields( array $sections ): array {
 		$shield_fields = $this->get_plugin_settings_fields();
 
 		foreach ( $sections as &$section ) {
@@ -160,9 +156,12 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Adds the Shield form-settings tooltip.
 	 *
-	 * @param array $tooltips Existing tooltips.
+	 * Public filter boundary. Gravity Forms intends this value to be an array,
+	 * but other callbacks can still pass through a non-array value.
 	 *
-	 * @return array
+	 * @param mixed $tooltips Existing tooltips.
+	 *
+	 * @return mixed
 	 */
 	public function add_tooltips( $tooltips ) {
 		if ( is_array( $tooltips ) ) {
@@ -190,7 +189,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			return false;
 		}
 
-		if ( ! $this->is_submission_context_supported( $form, $entry ) ) {
+		if ( ! $this->is_submission_context_supported( $entry ) ) {
 			return $is_spam;
 		}
 
@@ -205,7 +204,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 		$form_id = (int) rgar( $form, 'id' );
 
 		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
-			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf(__( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), 'Shield silentCAPTCHA' ) );
+			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf(__( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ) );
 		} else {
 			$this->flagged_forms[ $form_id ] = true;
 		}
@@ -259,7 +258,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			$entry['id'],
 			0,
 			self::SPAM_FILTER_NAME,
-			__( 'This entry has been marked as spam by Shield silentCAPTCHA.', 'gravity-forms-zero-spam' ),
+			sprintf( __( 'This entry has been marked as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ),
 			'gf-zero-spam',
 			'warning'
 		);
@@ -465,10 +464,9 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Determines if the current request is a supported submission context.
 	 *
-	 * @param array $form  Form object.
 	 * @param array $entry Entry object.
 	 */
-	private function is_submission_context_supported( $form, $entry ): bool {
+	private function is_submission_context_supported( $entry ): bool {
 		if ( GFCommon::is_preview() ) {
 			return false;
 		}
@@ -618,7 +616,9 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * Returns the form tooltip text for the current Shield state.
 	 */
 	private function get_form_tooltip_text( $form ): string {
-		$setting_scope = $this->get_form_setting_scope_text( $form );
+		$setting_scope = $this->has_saved_form_setting( $form )
+			? __( 'This setting is currently overriding the global default setting.', 'gravity-forms-zero-spam' )
+			: __( 'This setting is currently inheriting the global default setting.', 'gravity-forms-zero-spam' );
 
 		if ( ! $this->is_shield_available() ) {
 			return $setting_scope . ' ' . $this->get_unavailable_message();
@@ -747,14 +747,6 @@ HTML;
 		}
 
 		return $updated;
-	}
-
-	private function get_form_setting_scope_text( $form ): string {
-		if ( $this->has_saved_form_setting( $form ) ) {
-			return __( 'This setting is currently overriding the global default setting.', 'gravity-forms-zero-spam' );
-		}
-
-		return __( 'This setting is currently inheriting the global default setting.', 'gravity-forms-zero-spam' );
 	}
 
 	private function get_form_help_text(): string {

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -14,7 +14,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	const SETTING_KEY      = 'shield_silent_captcha';
 	const PERSIST_KEY      = 'shield_silent_captcha_persist';
 	const STATUS_FIELD_KEY = 'shield_silent_captcha_status';
-	const HELP_URL         = 'https://clk.shldscrty.com/gravityformszerospamsilentcaptcha';
+	const HELP_URL         = 'https://www.gravitykit.com/zero-spam-shield-silentcaptcha/?utm_source=plugin&utm_campaign=zero-spam&utm_content=shield-learn-more';
 	const SPAM_FILTER_NAME = 'Shield silentCAPTCHA';
 
 	/**

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -6,43 +6,69 @@ if ( ! defined( 'WPINC' ) ) {
 
 /**
  * Shield silentCAPTCHA integration for Gravity Forms Zero Spam.
+ *
+ * @since TBD
  */
 class GF_Zero_Spam_Shield_Silent_Captcha {
 
-	private const SETTING_KEY      = 'shield_silent_captcha';
-	private const PERSIST_KEY      = 'shield_silent_captcha_persist';
-	private const STATUS_FIELD_KEY = 'shield_silent_captcha_status';
-	private const HELP_URL         = 'https://clk.shldscrty.com/gravityformszerospamsilentcaptcha';
-	private const SPAM_FILTER_NAME = 'Shield silentCAPTCHA';
+	const SETTING_KEY      = 'shield_silent_captcha';
+	const PERSIST_KEY      = 'shield_silent_captcha_persist';
+	const STATUS_FIELD_KEY = 'shield_silent_captcha_status';
+	const HELP_URL         = 'https://clk.shldscrty.com/gravityformszerospamsilentcaptcha';
+	const SPAM_FILTER_NAME = 'Shield silentCAPTCHA';
 
 	/**
 	 * Add-on instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var GF_Zero_Spam_AddOn
 	 */
-	private GF_Zero_Spam_AddOn $addon;
+	private $addon;
 
 	/**
 	 * Cached Shield availability after plugins_loaded.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool|null
 	 */
-	private ?bool $shield_available = null;
+	private $shield_available;
 
 	/**
 	 * Cached threshold-zero state after plugins_loaded.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool|null
 	 */
-	private ?bool $shield_threshold_zero = null;
+	private $shield_threshold_zero;
 
 	/**
-	 * Shield-flagged form IDs used for the entry-note fallback path.
+	 * Shield-flagged form IDs during the current request.
+	 *
+	 * Set by filter_entry_is_spam() when Shield flags a form and GFCommon::set_spam_filter()
+	 * is unavailable. Read and cleared by maybe_add_entry_note() to add a fallback entry note.
+	 *
+	 * @since TBD
 	 *
 	 * @var array<int, bool>
 	 */
-	private array $flagged_forms = [];
+	private $flagged_forms = [];
 
+	/**
+	 * @since TBD
+	 *
+	 * @param GF_Zero_Spam_AddOn $addon Add-on instance.
+	 */
 	public function __construct( GF_Zero_Spam_AddOn $addon ) {
 		$this->addon = $addon;
 	}
 
 	/**
 	 * Registers Shield hooks.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */
@@ -57,6 +83,12 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Adds Shield fields to the existing Spam Blocking plugin settings section.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $sections Settings sections.
+	 *
+	 * @return array
 	 */
 	public function add_plugin_settings_fields( array $sections ): array {
 		$shield_fields = $this->get_plugin_settings_fields();
@@ -80,17 +112,17 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Normalizes Shield plugin settings before save.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $settings Settings array.
 	 *
 	 * @return array
 	 */
 	public function normalize_plugin_settings( $settings ) {
 		$submitted = $settings[ self::SETTING_KEY ] ?? null;
-		$persisted = rgar( $settings, self::PERSIST_KEY );
-
-		if ( null === $persisted ) {
-			$persisted = rgpost( '_gform_setting_' . self::PERSIST_KEY );
-		}
+		$persisted = array_key_exists( self::PERSIST_KEY, $settings )
+			? $settings[ self::PERSIST_KEY ]
+			: rgpost( '_gform_setting_' . self::PERSIST_KEY );
 
 		$settings[ self::SETTING_KEY ] = $this->resolve_setting_value_for_save(
 			$submitted,
@@ -105,6 +137,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Adds Shield per-form fields after the existing Zero Spam toggle.
+	 *
+	 * @since TBD
 	 *
 	 * @param array $fields Settings sections.
 	 * @param array $form   Current form object.
@@ -130,12 +164,15 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Normalizes Shield form settings before save.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $form Form object.
 	 *
 	 * @return array
 	 */
 	public function normalize_form_settings( $form ) {
-		$submitted         = rgpost( '_gform_setting_' . self::SETTING_KEY );
+		$post_key          = '_gform_setting_' . self::SETTING_KEY;
+		$submitted         = isset( $_POST[ $post_key ] ) ? rgpost( $post_key ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified by GF's form settings save handler.
 		$persisted         = rgpost( '_gform_setting_' . self::PERSIST_KEY );
 		$had_saved_setting = $this->has_saved_form_setting( $form );
 		$current_value     = $this->get_effective_form_setting_value( $form );
@@ -159,20 +196,32 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * Public filter boundary. Gravity Forms intends this value to be an array,
 	 * but other callbacks can still pass through a non-array value.
 	 *
+	 * @since TBD
+	 *
 	 * @param mixed $tooltips Existing tooltips.
 	 *
 	 * @return mixed
 	 */
 	public function add_tooltips( $tooltips ) {
-		if ( is_array( $tooltips ) ) {
-			$tooltips[ self::SETTING_KEY ] = esc_html( $this->get_form_tooltip_text( $this->addon->get_current_form() ) );
+		if ( ! is_array( $tooltips ) ) {
+			return $tooltips;
 		}
+
+		$form = $this->addon->get_current_form();
+
+		if ( empty( $form ) ) {
+			return $tooltips;
+		}
+
+		$tooltips[ self::SETTING_KEY ] = esc_html( $this->get_form_tooltip_text( $form ) );
 
 		return $tooltips;
 	}
 
 	/**
 	 * Flags the entry as spam when Shield returns a strict true verdict.
+	 *
+	 * @since TBD
 	 *
 	 * @param bool  $is_spam Existing spam state.
 	 * @param array $form    Form object.
@@ -204,7 +253,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 		$form_id = (int) rgar( $form, 'id' );
 
 		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
-			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf(__( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ) );
+			/* translators: %s: spam filter name. */
+			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf( __( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ) );
 		} else {
 			$this->flagged_forms[ $form_id ] = true;
 		}
@@ -214,6 +264,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Aborts Save and Continue draft creation when Shield returns a strict true verdict.
+	 *
+	 * @since TBD
 	 *
 	 * @param bool  $do_abort Existing abort state.
 	 * @param array $form     Form object.
@@ -239,6 +291,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Adds a fallback entry note when GFCommon::set_spam_filter() is unavailable.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $entry Entry object.
 	 *
 	 * @return void
@@ -258,6 +312,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			$entry['id'],
 			0,
 			self::SPAM_FILTER_NAME,
+			/* translators: %s: spam filter name. */
 			sprintf( __( 'This entry has been marked as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ),
 			'gf-zero-spam',
 			'warning'
@@ -268,6 +323,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Renders the plugin-settings status/help field.
+	 *
+	 * @since TBD
 	 *
 	 * @param array $field Field config.
 	 * @param bool  $echo  Whether to echo markup.
@@ -293,6 +350,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 *
 	 * Emits the disable-script fallback when Shield is unavailable and the inline
 	 * threshold warning when Shield is available but its bot threshold is zero.
+	 *
+	 * @since TBD
 	 *
 	 * @param array $field Field config.
 	 * @param bool  $echo  Whether to echo markup.
@@ -321,6 +380,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Builds the Shield plugin settings field definitions.
 	 *
+	 * @since TBD
+	 *
 	 * @return array<int, array<string, mixed>>
 	 */
 	private function get_plugin_settings_fields(): array {
@@ -348,6 +409,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Builds the Shield form settings field definitions.
+	 *
+	 * @since TBD
 	 *
 	 * @param array $form Form object.
 	 *
@@ -382,6 +445,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Returns the stored global Shield setting in normalized string form.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
 	 */
 	private function get_plugin_setting_value(): string {
 		return $this->normalize_setting_value( $this->addon->get_plugin_setting( self::SETTING_KEY ) );
@@ -390,7 +457,11 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Determines whether the form has a saved Shield setting.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $form Form object.
+	 *
+	 * @return bool
 	 */
 	private function has_saved_form_setting( $form ): bool {
 		return is_array( $form ) && array_key_exists( self::SETTING_KEY, $form );
@@ -399,7 +470,11 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Returns the saved per-form Shield setting when present.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $form Form object.
+	 *
+	 * @return string|null
 	 */
 	private function get_saved_form_setting_value( $form ): ?string {
 		if ( ! $this->has_saved_form_setting( $form ) ) {
@@ -412,7 +487,11 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Returns the effective Shield setting for the form.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $form Form object.
+	 *
+	 * @return string
 	 */
 	private function get_effective_form_setting_value( $form ): string {
 		$saved_value = $this->get_saved_form_setting_value( $form );
@@ -423,7 +502,11 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Determines if Shield is enabled for the current form.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $form Form object.
+	 *
+	 * @return bool
 	 */
 	private function is_shield_enabled_for_form( $form ): bool {
 		return '1' === $this->get_effective_form_setting_value( $form );
@@ -432,7 +515,11 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Normalizes a stored toggle value into the committed string shape.
 	 *
+	 * @since TBD
+	 *
 	 * @param mixed $value Raw value.
+	 *
+	 * @return string
 	 */
 	private function normalize_setting_value( $value ): string {
 		return in_array( (string) $value, [ '1', 'true', 'on', 'yes' ], true ) ? '1' : '0';
@@ -441,20 +528,26 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Resolves the stored Shield setting value during a save operation.
 	 *
+	 * @since TBD
+	 *
 	 * @param mixed  $submitted     Submitted toggle value, if present.
 	 * @param mixed  $persisted     Hidden persisted value, if present.
 	 * @param string $current_value Current stored normalized value.
+	 *
+	 * @return string
 	 */
 	private function resolve_setting_value_for_save( $submitted, $persisted, string $current_value ): string {
 		if ( null !== $submitted ) {
 			return $this->normalize_setting_value( $submitted );
 		}
 
-		if ( ! $this->is_shield_available() ) {
-			if ( null !== $persisted ) {
-				return $this->normalize_setting_value( $persisted );
-			}
+		// Toggle was not submitted (disabled in UI or programmatic save). Prefer the
+		// hidden persist field, then the previously-stored value, then default to off.
+		if ( null !== $persisted && '' !== $persisted ) {
+			return $this->normalize_setting_value( $persisted );
+		}
 
+		if ( ! $this->is_shield_available() ) {
 			return $current_value;
 		}
 
@@ -464,7 +557,11 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Determines if the current request is a supported submission context.
 	 *
+	 * @since TBD
+	 *
 	 * @param array $entry Entry object.
+	 *
+	 * @return bool
 	 */
 	private function is_submission_context_supported( $entry ): bool {
 		if ( GFCommon::is_preview() ) {
@@ -480,11 +577,19 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			return false;
 		}
 
-		return !( isset( $entry['user_agent'] ) && 'API' === $entry['user_agent'] );
+		if ( isset( $entry['user_agent'] ) && 'API' === $entry['user_agent'] ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
 	 * Resolves the Shield verdict using the documented callable order.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool|null True if bot, false if not, null if undetermined.
 	 */
 	private function resolve_shield_bot_verdict(): ?bool {
 		if ( ! did_action( 'plugins_loaded' ) ) {
@@ -513,6 +618,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Determines if Shield is available for the current request.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
 	 */
 	private function is_shield_available(): bool {
 		if ( ! did_action( 'plugins_loaded' ) ) {
@@ -537,6 +646,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Determines if Shield is available and the threshold is zero.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
 	 */
 	private function is_threshold_zero(): bool {
 		if ( ! did_action( 'plugins_loaded' ) ) {
@@ -576,6 +689,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	}
 
 	/**
+	 * Returns the ordered list of Shield bot-detection callables.
+	 *
+	 * @since TBD
+	 *
 	 * @return array<int, string>
 	 */
 	private function get_shield_callables(): array {
@@ -586,6 +703,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	}
 
 	/**
+	 * Returns the ordered list of Shield threshold callables.
+	 *
+	 * @since TBD
+	 *
 	 * @return array<int, string>
 	 */
 	private function get_shield_threshold_callables(): array {
@@ -598,7 +719,11 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Normalizes the Shield verdict into a strict tri-state.
 	 *
+	 * @since TBD
+	 *
 	 * @param mixed $verdict Raw verdict.
+	 *
+	 * @return bool|null
 	 */
 	private function normalize_verdict( $verdict ): ?bool {
 		if ( true === $verdict ) {
@@ -614,6 +739,12 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Returns the form tooltip text for the current Shield state.
+	 *
+	 * @since TBD
+	 *
+	 * @param array|false $form Form object or false when no form context.
+	 *
+	 * @return string
 	 */
 	private function get_form_tooltip_text( $form ): string {
 		$setting_scope = $this->has_saved_form_setting( $form )
@@ -633,6 +764,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Returns the plugin-settings status text for the current Shield state.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
 	 */
 	private function get_plugin_status_text(): string {
 		if ( ! $this->is_shield_available() ) {
@@ -648,6 +783,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 	/**
 	 * Renders the plugin-settings status message with the Learn More link.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
 	 */
 	private function render_plugin_status_message(): string {
 		$style = $this->is_shield_available() && $this->is_threshold_zero()
@@ -666,7 +805,13 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	/**
 	 * Creates a tiny inline script to disable the visible Shield toggle.
 	 *
+	 * This is a defensive fallback alongside GF's native 'disabled' field property.
+	 *
+	 * @since TBD
+	 *
 	 * @param array<int, string> $field_names Candidate field names.
+	 *
+	 * @return string
 	 */
 	private function render_disable_control_script( $field_names ): string {
 		$field_names_json = wp_json_encode( array_values( $field_names ) );
@@ -704,8 +849,12 @@ HTML;
 	/**
 	 * Determines whether the section contains a given field name.
 	 *
+	 * @since TBD
+	 *
 	 * @param array  $section    Section config.
 	 * @param string $field_name Field name.
+	 *
+	 * @return bool
 	 */
 	private function section_contains_field( $section, $field_name ): bool {
 		foreach ( $section['fields'] as $field ) {
@@ -720,9 +869,13 @@ HTML;
 	/**
 	 * Inserts fields immediately after a named field, appending if not found.
 	 *
+	 * @since TBD
+	 *
 	 * @param array  $fields     Existing fields.
 	 * @param string $field_name Target field name.
 	 * @param array  $new_fields Fields to insert.
+	 *
+	 * @return array
 	 */
 	private function insert_fields_after_name( $fields, $field_name, $new_fields ): array {
 		$updated  = [];
@@ -749,18 +902,46 @@ HTML;
 		return $updated;
 	}
 
+	/**
+	 * Returns the form-level help text.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
 	private function get_form_help_text(): string {
 		return __( 'Runs Shield silentCAPTCHA server-side for this form. No field needs to be added to the form.', 'gravity-forms-zero-spam' );
 	}
 
+	/**
+	 * Returns the global-level help text.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
 	private function get_global_help_text(): string {
 		return __( 'Enable Shield silentCAPTCHA by default for forms. No field needs to be added to the form. Forms without their own Shield setting will use this default.', 'gravity-forms-zero-spam' );
 	}
 
+	/**
+	 * Returns the message shown when Shield is not available.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
 	private function get_unavailable_message(): string {
 		return __( 'Shield silentCAPTCHA is currently unavailable because Shield Security is not installed or active. This setting is disabled until Shield becomes available again.', 'gravity-forms-zero-spam' );
 	}
 
+	/**
+	 * Returns the message shown when Shield's bot threshold is zero.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
 	private function get_threshold_zero_message(): string {
 		return __( 'Shield silentCAPTCHA is available, but Shield\'s bot threshold is 0, so it will not flag submissions until that threshold is increased.', 'gravity-forms-zero-spam' );
 	}

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -57,6 +57,18 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	private $flagged_forms = [];
 
 	/**
+	 * Cached Shield bot verdict for the current request.
+	 *
+	 * Avoids calling Shield's callable twice on Save & Continue submissions,
+	 * where both filter_entry_is_spam() and maybe_abort_submission() fire.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool|null|string 'unset' when not yet resolved, bool|null after.
+	 */
+	private $cached_verdict = 'unset';
+
+	/**
 	 * @since TBD
 	 *
 	 * @param GF_Zero_Spam_AddOn $addon Add-on instance.
@@ -592,9 +604,15 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * @return bool|null True if bot, false if not, null if undetermined.
 	 */
 	private function resolve_shield_bot_verdict(): ?bool {
+		if ( 'unset' !== $this->cached_verdict ) {
+			return $this->cached_verdict;
+		}
+
 		if ( ! did_action( 'plugins_loaded' ) ) {
 			return null;
 		}
+
+		$this->cached_verdict = null;
 
 		foreach ( $this->get_shield_callables() as $callable ) {
 			if ( ! is_callable( $callable ) ) {
@@ -608,7 +626,10 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			}
 
 			$normalized = $this->normalize_verdict( $verdict );
+
 			if ( null !== $normalized ) {
+				$this->cached_verdict = $normalized;
+
 				return $normalized;
 			}
 		}

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -14,7 +14,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	const SETTING_KEY      = 'shield_silent_captcha';
 	const PERSIST_KEY      = 'shield_silent_captcha_persist';
 	const STATUS_FIELD_KEY = 'shield_silent_captcha_status';
-	const HELP_URL         = 'https://www.gravitykit.com/zero-spam-shield-silentcaptcha/?utm_source=plugin&utm_campaign=zero-spam&utm_content=shield-learn-more';
+	const HELP_URL         = 'https://www.gravitykit.com/docs/gravity-forms-zero-spam/shield-silentcaptcha/?utm_source=plugin&utm_campaign=zero-spam&utm_content=shield-learn-more';
 	const SPAM_FILTER_NAME = 'Shield silentCAPTCHA';
 
 	/**

--- a/includes/class-gf-zero-spam-shield-silent-captcha.php
+++ b/includes/class-gf-zero-spam-shield-silent-captcha.php
@@ -69,6 +69,15 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	private $cached_verdict = 'unset';
 
 	/**
+	 * Pending verdict notes for already-flagged entries, keyed by form ID.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<int, array{text: string, type: string}>
+	 */
+	private $secondary_notes = [];
+
+	/**
 	 * @since TBD
 	 *
 	 * @param GF_Zero_Spam_AddOn $addon Add-on instance.
@@ -88,7 +97,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 		add_filter( 'gform_form_settings_fields', [ $this, 'add_form_settings_fields' ], 11, 2 );
 		add_filter( 'gform_pre_form_settings_save', [ $this, 'normalize_form_settings' ] );
 		add_filter( 'gform_tooltips', [ $this, 'add_tooltips' ] );
-		add_filter( 'gform_entry_is_spam', [ $this, 'filter_entry_is_spam' ], 20, 3 );
+		add_filter( 'gform_entry_is_spam', [ $this, 'filter_entry_is_spam' ], $this->addon->get_spam_check_priority( 'shield' ), 3 );
 		add_filter( 'gform_abort_submission_with_confirmation', [ $this, 'maybe_abort_submission' ], 30, 2 );
 		add_action( 'gform_entry_created', [ $this, 'maybe_add_entry_note' ] );
 	}
@@ -183,12 +192,36 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * @return array
 	 */
 	public function normalize_form_settings( $form ) {
-		$post_key          = '_gform_setting_' . self::SETTING_KEY;
-		$submitted         = isset( $_POST[ $post_key ] ) ? rgpost( $post_key ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified by GF's form settings save handler.
-		$persisted         = rgpost( '_gform_setting_' . self::PERSIST_KEY );
-		$had_saved_setting = $this->has_saved_form_setting( $form );
-		$current_value     = $this->get_effective_form_setting_value( $form );
-		$resolved          = $this->resolve_setting_value_for_save( $submitted, $persisted, $current_value );
+		$post_key  = '_gform_setting_' . self::SETTING_KEY;
+		$submitted = isset( $_POST[ $post_key ] ) ? rgpost( $post_key ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified by GF's form settings save handler.
+		$persisted = rgpost( '_gform_setting_' . self::PERSIST_KEY );
+
+		// GF merges the materialized setting values into $form before this filter fires,
+		// so pre-save state must come from the stored form meta.
+		$saved_form = GFFormsModel::get_form_meta( (int) rgar( $form, 'id' ) );
+
+		if ( ! is_array( $saved_form ) ) {
+			$saved_form = [];
+		}
+
+		$had_saved_setting = $this->has_saved_form_setting( $saved_form );
+
+		// The Shield fields are dependency-hidden while the Zero Spam master toggle is off,
+		// so nothing was visible to submit; keep the stored state untouched.
+		if ( empty( rgpost( '_gform_setting_enableGFZeroSpam' ) ) ) {
+			if ( $had_saved_setting ) {
+				$form[ self::SETTING_KEY ] = $this->normalize_setting_value( $saved_form[ self::SETTING_KEY ] );
+			} else {
+				unset( $form[ self::SETTING_KEY ] );
+			}
+
+			unset( $form[ self::PERSIST_KEY ], $form[ self::STATUS_FIELD_KEY ] );
+
+			return $form;
+		}
+
+		$current_value = $this->get_effective_form_setting_value( $saved_form );
+		$resolved      = $this->resolve_setting_value_for_save( $submitted, $persisted, $current_value );
 
 		// Keep missing-key inheritance intact unless the form already had an override or the user changed the value.
 		if ( ! $had_saved_setting && $resolved === $current_value ) {
@@ -243,7 +276,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 */
 	public function filter_entry_is_spam( $is_spam, $form, $entry ) {
 		if ( $is_spam ) {
-			return $is_spam;
+			return $this->evaluate_already_flagged_entry( $is_spam, $form, $entry );
 		}
 
 		if ( GFCommon::current_user_can_any( 'gravityforms_edit_entries' ) ) {
@@ -264,14 +297,79 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 
 		$form_id = (int) rgar( $form, 'id' );
 
+		if ( method_exists( 'GF_Zero_Spam', 'record_non_token_spam_source' ) ) {
+			GF_Zero_Spam::record_non_token_spam_source( $form_id, 'shield_silent_captcha' );
+		}
+
 		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
-			/* translators: %s: spam filter name. */
-			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, sprintf( __( 'This submission was flagged as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ) );
+			$message = strtr(
+				/* translators: placeholders in [brackets] are replaced and must not be translated. */
+				__( 'This submission was flagged as spam by [filter].', 'gravity-forms-zero-spam' ),
+				[ '[filter]' => self::SPAM_FILTER_NAME ]
+			);
+
+			GFCommon::set_spam_filter( $form_id, self::SPAM_FILTER_NAME, $message );
 		} else {
 			$this->flagged_forms[ $form_id ] = true;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Evaluates and records the Shield verdict for an already-flagged entry when the stop setting is off.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool  $is_spam Existing spam state (always returned unchanged).
+	 * @param array $form    Form object.
+	 * @param array $entry   Entry object.
+	 *
+	 * @return bool
+	 */
+	private function evaluate_already_flagged_entry( $is_spam, $form, $entry ) {
+		if ( $this->addon->should_stop_after_first_detection() ) {
+			return $is_spam;
+		}
+
+		if ( GFCommon::current_user_can_any( 'gravityforms_edit_entries' ) ) {
+			return $is_spam;
+		}
+
+		if ( ! $this->is_submission_context_supported( $entry ) ) {
+			return $is_spam;
+		}
+
+		if ( ! $this->is_shield_enabled_for_form( $form ) ) {
+			return $is_spam;
+		}
+
+		$verdict = $this->resolve_shield_bot_verdict();
+
+		if ( null === $verdict ) {
+			return $is_spam;
+		}
+
+		$form_id = (int) rgar( $form, 'id' );
+
+		// A bot verdict keeps the AI rescue guard aware of Shield regardless of check order.
+		if ( true === $verdict && method_exists( 'GF_Zero_Spam', 'record_non_token_spam_source' ) ) {
+			GF_Zero_Spam::record_non_token_spam_source( $form_id, 'shield_silent_captcha' );
+		}
+
+		if ( true === $verdict ) {
+			$this->secondary_notes[ $form_id ] = [
+				'text' => __( 'Shield silentCAPTCHA also identified this submission as spam.', 'gravity-forms-zero-spam' ),
+				'type' => 'warning',
+			];
+		} else {
+			$this->secondary_notes[ $form_id ] = [
+				'text' => __( 'Shield silentCAPTCHA did not identify this submission as spam.', 'gravity-forms-zero-spam' ),
+				'type' => 'success',
+			];
+		}
+
+		return $is_spam;
 	}
 
 	/**
@@ -312,6 +410,8 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	public function maybe_add_entry_note( $entry ) {
 		$form_id = (int) rgar( $entry, 'form_id' );
 
+		$this->maybe_add_secondary_verdict_note( $entry, $form_id );
+
 		if ( 'spam' !== rgar( $entry, 'status' ) || empty( $this->flagged_forms[ $form_id ] ) ) {
 			return;
 		}
@@ -324,13 +424,41 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 			$entry['id'],
 			0,
 			self::SPAM_FILTER_NAME,
-			/* translators: %s: spam filter name. */
-			sprintf( __( 'This entry has been marked as spam by %s.', 'gravity-forms-zero-spam' ), self::SPAM_FILTER_NAME ),
+			strtr(
+				/* translators: placeholders in [brackets] are replaced and must not be translated. */
+				__( 'This entry has been marked as spam by [filter].', 'gravity-forms-zero-spam' ),
+				[ '[filter]' => self::SPAM_FILTER_NAME ]
+			),
 			'gf-zero-spam',
 			'warning'
 		);
 
 		unset( $this->flagged_forms[ $form_id ] );
+	}
+
+	/**
+	 * Adds the scheduled Shield verdict note to an entry flagged by another check.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $entry   Entry object.
+	 * @param int   $form_id Form ID.
+	 *
+	 * @return void
+	 */
+	private function maybe_add_secondary_verdict_note( $entry, $form_id ) {
+		if ( empty( $this->secondary_notes[ $form_id ] ) ) {
+			return;
+		}
+
+		$note = $this->secondary_notes[ $form_id ];
+		unset( $this->secondary_notes[ $form_id ] );
+
+		if ( ! method_exists( 'GFAPI', 'add_note' ) ) {
+			return;
+		}
+
+		GFAPI::add_note( (int) $entry['id'], 0, self::SPAM_FILTER_NAME, $note['text'], 'gf-zero-spam', $note['type'] );
 	}
 
 	/**
@@ -429,7 +557,15 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * @return array<int, array<string, mixed>>
 	 */
 	private function get_form_settings_fields( $form ): array {
-		$current_value = $this->get_effective_form_setting_value( $form );
+		$current_value        = $this->get_effective_form_setting_value( $form );
+		$zero_spam_dependency = [
+			'live'   => true,
+			'fields' => [
+				[
+					'field' => 'enableGFZeroSpam',
+				],
+			],
+		];
 
 		return [
 			[
@@ -439,6 +575,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 				'tooltip'       => gform_tooltip( self::SETTING_KEY, '', true ),
 				'default_value' => $current_value,
 				'disabled'      => ! $this->is_shield_available(),
+				'dependency'    => $zero_spam_dependency,
 			],
 			[
 				'type'          => 'hidden',
@@ -446,11 +583,12 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 				'default_value' => $current_value,
 			],
 			[
-				'hidden'   => ! $this->is_threshold_zero(),
-				'type'     => 'html',
-				'name'     => self::STATUS_FIELD_KEY,
-				'label'    => '',
-				'callback' => [ $this, 'render_form_status_field' ],
+				'hidden'     => ! $this->is_threshold_zero(),
+				'type'       => 'html',
+				'name'       => self::STATUS_FIELD_KEY,
+				'label'      => '',
+				'callback'   => [ $this, 'render_form_status_field' ],
+				'dependency' => $zero_spam_dependency,
 			],
 		];
 	}
@@ -521,7 +659,36 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * @return bool
 	 */
 	private function is_shield_enabled_for_form( $form ): bool {
+		// The Zero Spam master gate covers the whole pipeline, Shield included.
+		if ( ! $this->is_zero_spam_gate_open( $form ) ) {
+			return false;
+		}
+
 		return '1' === $this->get_effective_form_setting_value( $form );
+	}
+
+	/**
+	 * Resolves the Zero Spam master gate through the public filter, like the token and AI checks.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $form Form object.
+	 *
+	 * @return bool
+	 */
+	private function is_zero_spam_gate_open( $form ): bool {
+		$form_id = (int) rgar( $form, 'id' );
+		$enabled = true;
+
+		if ( $form_id > 0 ) {
+			/** This filter is documented in includes/class-gf-zero-spam.php. */
+			$enabled = gf_apply_filters( 'gf_zero_spam_check_key_field', $form_id, $enabled, $form, [] );
+		} else {
+			/** This filter is documented in includes/class-gf-zero-spam.php. */
+			$enabled = apply_filters( 'gf_zero_spam_check_key_field', $enabled, $form );
+		}
+
+		return false !== $enabled;
 	}
 
 	/**
@@ -549,21 +716,22 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 * @return string
 	 */
 	private function resolve_setting_value_for_save( $submitted, $persisted, string $current_value ): string {
-		if ( null !== $submitted ) {
+		if ( null !== $submitted && '' !== $submitted ) {
 			return $this->normalize_setting_value( $submitted );
 		}
 
-		// Toggle was not submitted (disabled in UI or programmatic save). Prefer the
-		// hidden persist field, then the previously-stored value, then default to off.
+		// Unchecked and disabled toggles both arrive without an affirmative value. Shield
+		// availability disambiguates: available means the toggle was interactive (no value =
+		// unchecked); unavailable means it was disabled, so preserve the previous value.
+		if ( $this->is_shield_available() ) {
+			return '0';
+		}
+
 		if ( null !== $persisted && '' !== $persisted ) {
 			return $this->normalize_setting_value( $persisted );
 		}
 
-		if ( ! $this->is_shield_available() ) {
-			return $current_value;
-		}
-
-		return '0';
+		return $current_value;
 	}
 
 	/**
@@ -644,7 +812,7 @@ class GF_Zero_Spam_Shield_Silent_Captcha {
 	 *
 	 * @return bool
 	 */
-	private function is_shield_available(): bool {
+	public function is_shield_available(): bool {
 		if ( ! did_action( 'plugins_loaded' ) ) {
 			return false;
 		}

--- a/includes/class-gf-zero-spam.php
+++ b/includes/class-gf-zero-spam.php
@@ -34,6 +34,15 @@ class GF_Zero_Spam {
 	private static $non_token_spam_sources = [];
 
 	/**
+	 * Pending verdict notes for already-flagged entries, keyed by form ID.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<int, array{text: string, type: string}>
+	 */
+	private $secondary_notes = [];
+
+	/**
 	 * Instantiates the plugin on Gravity Forms loading.
 	 *
 	 * @since 1.0.5
@@ -163,7 +172,12 @@ class GF_Zero_Spam {
 		add_action( 'gform_register_init_scripts', [ $this, 'add_key_field' ], 1 );
 		add_filter( 'gform_pre_process', [ __CLASS__, 'reset_request_markers' ] );
 		add_filter( 'gform_get_form_filter', [ $this, 'enqueue_script' ], 10, 2 );
-		add_filter( 'gform_entry_is_spam', [ $this, 'check_key_field' ], 10, 3 );
+
+		$priority = method_exists( 'GF_Zero_Spam_AddOn', 'get_instance' )
+			? GF_Zero_Spam_AddOn::get_instance()->get_spam_check_priority( 'token' )
+			: 12;
+
+		add_filter( 'gform_entry_is_spam', [ $this, 'check_key_field' ], $priority, 3 );
 		add_filter( 'gform_incomplete_submission_pre_save', [ $this, 'add_zero_spam_key_to_entry' ], 10, 3 );
 		add_filter( 'gform_abort_submission_with_confirmation', [ $this, 'maybe_abort_submission' ], 20, 2 );
 		add_action( 'admin_notices', [ $this, 'migration_notice' ] );
@@ -435,13 +449,16 @@ class GF_Zero_Spam {
 	 * @return bool True: it's spam; False: it's not spam!
 	 */
 	public function check_key_field( $is_spam = false, $form = [], $entry = [] ) {
-		// If the user can edit entries, they're not a spammer. It may be spam, but it's their prerogative.
+		// If the user can edit entries, they're not a spammer. It may be spam, but it's their
+		// prerogative. Returns the incoming status so another check's verdict is never cleared.
 		if ( GFCommon::current_user_can_any( 'gravityforms_edit_entries' ) ) {
-			return false;
+			return $is_spam;
 		}
 
-		// Another filter (e.g. honeypot) already flagged this as spam.
-		if ( $is_spam ) {
+		$already_flagged = (bool) $is_spam;
+
+		// Another filter (e.g. honeypot) already flagged this as spam; evaluate anyway when the stop setting is off.
+		if ( $already_flagged && $this->should_stop_after_first_detection() ) {
 			return $is_spam;
 		}
 
@@ -477,6 +494,40 @@ class GF_Zero_Spam {
 			return $is_spam;
 		}
 
+		$verdict = $this->get_token_verdict( $form );
+
+		// Record the verdict as an entry note without changing the existing spam status.
+		if ( $already_flagged ) {
+			$this->schedule_secondary_verdict_note( $form, $verdict );
+
+			return $is_spam;
+		}
+
+		if ( ! $verdict['is_spam'] ) {
+			return false;
+		}
+
+		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
+			GFCommon::set_spam_filter( rgar( $form, 'id' ), 'Zero Spam', $verdict['reason'] );
+		} else {
+			add_action( 'gform_entry_created', [ $this, 'add_entry_note' ] );
+		}
+
+		$this->record_token_rejection( $verdict['reason_code'], $form, $entry, __METHOD__ );
+
+		return true;
+	}
+
+	/**
+	 * Evaluates the token or legacy-key verdict for the current submission without side effects.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $form The form currently being processed.
+	 *
+	 * @return array{is_spam: bool, reason: string, reason_code: string} The verdict.
+	 */
+	private function get_token_verdict( $form ) {
 		$submitted_token = rgpost( 'gf_zero_spam_token' );
 
 		// Validate signed token if present.
@@ -484,7 +535,11 @@ class GF_Zero_Spam {
 			$result = GF_Zero_Spam_Token::validate( $submitted_token, (int) rgar( $form, 'id' ) );
 
 			if ( $result['valid'] ) {
-				return false;
+				return [
+					'is_spam'     => false,
+					'reason'      => '',
+					'reason_code' => '',
+				];
 			}
 
 			$reason_map = [
@@ -496,51 +551,119 @@ class GF_Zero_Spam {
 			];
 
 			$reason_code = (string) $result['reason'];
-			$reason      = isset( $reason_map[ $reason_code ] ) ? $reason_map[ $reason_code ] : $reason_code;
 
-			if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
-				GFCommon::set_spam_filter( rgar( $form, 'id' ), 'Zero Spam', $reason );
-			} else {
-				add_action( 'gform_entry_created', [ $this, 'add_entry_note' ] );
-			}
-
-			$this->record_token_rejection( $reason_code, $form, $entry, __METHOD__ );
-
-			return true;
+			return [
+				'is_spam'     => true,
+				'reason'      => isset( $reason_map[ $reason_code ] ) ? $reason_map[ $reason_code ] : $reason_code,
+				'reason_code' => $reason_code,
+			];
 		}
 
 		// Fall back to legacy static key during migration.
 		$submitted_key = rgpost( 'gf_zero_spam_key' );
-		$reason        = '';
-		$reason_code   = '';
 
 		if ( rgblank( $submitted_key ) ) {
-			$is_spam     = true;
-			$reason      = __( 'The submission did not include a spam prevention token.', 'gravity-forms-zero-spam' );
-			$reason_code = 'legacy_missing';
+			return [
+				'is_spam'     => true,
+				'reason'      => __( 'The submission did not include a spam prevention token.', 'gravity-forms-zero-spam' ),
+				'reason_code' => 'legacy_missing',
+			];
+		}
+
+		$legacy_result = $this->validate_legacy_key( $submitted_key );
+
+		if ( true !== $legacy_result ) {
+			return [
+				'is_spam'     => true,
+				'reason'      => (string) $legacy_result,
+				'reason_code' => 'legacy_invalid',
+			];
+		}
+
+		return [
+			'is_spam'     => false,
+			'reason'      => '',
+			'reason_code' => '',
+		];
+	}
+
+	/**
+	 * Schedules an entry note recording the token verdict for an already-flagged entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $form    The form currently being processed.
+	 * @param array $verdict The token verdict.
+	 *
+	 * @return void
+	 */
+	private function schedule_secondary_verdict_note( $form, $verdict ) {
+		$form_id = (int) rgar( $form, 'id' );
+
+		if ( $form_id < 1 ) {
+			return;
+		}
+
+		if ( $verdict['is_spam'] ) {
+			$note = [
+				'text' => strtr(
+					/* translators: placeholders in [brackets] are replaced and must not be translated. */
+					__( 'The Zero Spam token check also flagged this submission: [reason]', 'gravity-forms-zero-spam' ),
+					[ '[reason]' => $verdict['reason'] ]
+				),
+				'type' => 'warning',
+			];
 		} else {
-			$legacy_result = $this->validate_legacy_key( $submitted_key );
-
-			if ( true !== $legacy_result ) {
-				$is_spam     = true;
-				$reason      = $legacy_result;
-				$reason_code = 'legacy_invalid';
-			}
+			$note = [
+				'text' => __( 'The Zero Spam token check found a valid token for this submission.', 'gravity-forms-zero-spam' ),
+				'type' => 'success',
+			];
 		}
 
-		if ( ! $is_spam ) {
-			return $is_spam;
+		$this->secondary_notes[ $form_id ] = $note;
+
+		add_action( 'gform_entry_created', [ $this, 'add_secondary_verdict_note' ] );
+	}
+
+	/**
+	 * Adds the scheduled token verdict note to the created entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $entry The created entry.
+	 *
+	 * @return void
+	 */
+	public function add_secondary_verdict_note( $entry ) {
+		$form_id = (int) rgar( $entry, 'form_id' );
+
+		if ( empty( $this->secondary_notes[ $form_id ] ) ) {
+			return;
 		}
 
-		if ( method_exists( 'GFCommon', 'set_spam_filter' ) ) {
-			GFCommon::set_spam_filter( rgar( $form, 'id' ), 'Zero Spam', $reason );
-		} else {
-			add_action( 'gform_entry_created', [ $this, 'add_entry_note' ] );
+		$note = $this->secondary_notes[ $form_id ];
+		unset( $this->secondary_notes[ $form_id ] );
+
+		if ( ! method_exists( 'GFAPI', 'add_note' ) ) {
+			return;
 		}
 
-		$this->record_token_rejection( $reason_code, $form, $entry, __METHOD__ );
+		GFAPI::add_note( $entry['id'], 0, 'Zero Spam', $note['text'], 'gf-zero-spam', $note['type'] );
+	}
 
-		return $is_spam;
+	/**
+	 * Returns whether later checks are skipped once a check flags a submission as spam.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether to stop after the first detection.
+	 */
+	private function should_stop_after_first_detection() {
+		if ( ! method_exists( 'GF_Zero_Spam_AddOn', 'get_instance' ) ) {
+			return true;
+		}
+
+		return GF_Zero_Spam_AddOn::get_instance()->should_stop_after_first_detection();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,10 @@ Zero Spam is better than the Gravity Forms anti-spam honeypot field. If you're g
 
 If you only want the plugin for specific forms, that's possible! The plugin adds a simple "Prevent spam using Gravity Forms Zero Spam" setting to each form (requires Gravity Forms 2.5 or newer).
 
+## Works with Shield Security
+
+If the [Shield Security](https://wordpress.org/plugins/wp-simple-firewall/) plugin is active, its silentCAPTCHA bot detection can be used as an additional spam signal — enabled globally or per form. You can also control the order in which the plugin's spam checks run.
+
 ## Spam report emails
 
 Spam summary report emails are disabled by default. Once enabled, a spam summary that includes the number of entries per-form will be sent via email.
@@ -109,6 +113,13 @@ First, **de-activate and re-activate the plugin**. Then let us know on the suppo
 You can enable a spam summary report email. This email will be sent to the email address configured in the "Spam Summary Email" setting on the Gravity Forms "Forms" menu, click Settings, then click the Zero Spam tab.
 
 == Changelog ==
+
+= TBD =
+
+* Added: Shield silentCAPTCHA integration — when the [Shield Security](https://wordpress.org/plugins/wp-simple-firewall/) plugin is active, its bot detection becomes an additional spam signal, with a global default and per-form override (thanks, Paul Goodchild!)
+* Added: "Spam Check Order" settings — control the order the token check, Shield silentCAPTCHA, and AI Spam Review run in, and whether to stop checking once a submission is flagged as spam
+* Improved: The "Prevent spam using Gravity Forms Zero Spam" form setting now acts as a master switch — disabling it turns off all of the plugin's spam checks for that form, including Shield silentCAPTCHA and AI Spam Review
+* Fixed: A spam verdict from one check could be cleared when the submitter was logged in with entry-editing permissions
 
 = 1.9.0 on June 11, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,18 +91,11 @@ No. For that, we recommend Ben Marshall‘s [WordPress Zero Spam plugin](https:/
 
 New form submissions will not be checked using Zero Spam.
 
-= I only want on specific forms. How do I disable Zero Spam by default? =
+= I only want Zero Spam on specific forms. How do I do that? =
 
-To disable by default, from your Dashboard, go to Forms, then Settings, then the Zero Spam tab. Under the "Enable Zero Spam by Default" setting, choose "Disabled", then save the form.
+Keep the global "Enable Zero Spam by Default" setting set to "Enabled", then disable "Prevent spam using Gravity Forms Zero Spam" on each form you want excluded (see the previous question).
 
-Once you have saved the setting, to enable for specific forms:
-
-1. Go to the form
-2. Click on Settings
-3. Under Form Options, enable "Prevent spam using Gravity Forms Zero Spam". _Don't see the setting? This feature requires Gravity Forms 2.5 or newer._
-4. Save the settings
-
-Now that form will use Zero Spam.
+Note: choosing "Disabled" for "Enable Zero Spam by Default" turns off all of the plugin's spam checks for every form — per-form settings have no effect while the global setting is disabled.
 
 = All entries are going to spam. What can I do? =
 

--- a/tests/E2E/helpers/zs-helpers.js
+++ b/tests/E2E/helpers/zs-helpers.js
@@ -288,6 +288,94 @@ async function clearCapturedMail(request) {
 }
 
 /**
+ * Configure the Shield silentCAPTCHA E2E mock (tests/E2E/mu-plugins/zs-e2e-shield.php).
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {object} payload
+ * @param {boolean} [payload.available] - Define the shield_* callables so the integration sees Shield as installed.
+ * @param {'null'|'bot'|'human'|'throw'|'garbage'} [payload.verdict] - What the mocked bot check returns.
+ * @param {number} [payload.threshold] - Mocked silentCAPTCHA bot threshold.
+ */
+async function setShieldMock(request, payload = {}) {
+    return callJson(request, 'POST', '/shield', payload);
+}
+
+/**
+ * Read the Shield mock state, including how many times the bot check was called.
+ */
+async function getShieldMock(request) {
+    return callJson(request, 'GET', '/shield');
+}
+
+/**
+ * Reset the Shield mock (Shield becomes unavailable again).
+ */
+async function resetShieldMock(request) {
+    return callJson(request, 'DELETE', '/shield');
+}
+
+/**
+ * Read the raw stored global Shield setting: { present, value }.
+ */
+async function getShieldPluginSetting(request) {
+    return callJson(request, 'GET', '/shield/plugin-setting');
+}
+
+/**
+ * Seed or remove the stored global Shield setting without going through the UI.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {{ value?: string, remove?: boolean }} payload
+ */
+async function setShieldPluginSetting(request, payload = {}) {
+    return callJson(request, 'POST', '/shield/plugin-setting', payload);
+}
+
+/**
+ * Read the raw per-form Shield meta straight from stored form meta:
+ * { present, value }. `present: false` means the form inherits the global default.
+ */
+async function getFormShieldMeta(request, formId) {
+    return callJson(request, 'GET', `/form/${formId}/shield-meta`);
+}
+
+/**
+ * Seed or remove the per-form Shield override without going through the UI.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {number} formId
+ * @param {{ value?: string, remove?: boolean }} payload
+ */
+async function setFormShieldMeta(request, formId, payload = {}) {
+    return callJson(request, 'POST', `/form/${formId}/shield-meta`, payload);
+}
+
+/**
+ * Read the raw stored Spam Check Order settings: { order: [v1, v2, v3], stop }.
+ * Array entries and stop are null when the key is not stored.
+ */
+async function getCheckOrder(request) {
+    return callJson(request, 'GET', '/check-order');
+}
+
+/**
+ * Seed the Spam Check Order settings without going through the UI.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {{ order?: string[], stop?: boolean }} payload - order: 3 slugs from token|shield|ai.
+ */
+async function setCheckOrder(request, payload = {}) {
+    return callJson(request, 'POST', '/check-order', payload);
+}
+
+/**
+ * Remove the stored Spam Check Order settings (back to defaults).
+ */
+async function resetCheckOrder(request) {
+    return callJson(request, 'DELETE', '/check-order');
+}
+
+/**
  * Locate the live Zero Spam input element on a rendered Gravity Form.
  *
  * The plugin injects a hidden `gf_zero_spam_token` (JS path) and may also leave
@@ -339,6 +427,16 @@ module.exports = {
     clearCapturedMail,
     getZeroSpamInput,
     stripZeroSpamInputs,
+    setShieldMock,
+    getShieldMock,
+    resetShieldMock,
+    getShieldPluginSetting,
+    setShieldPluginSetting,
+    getFormShieldMeta,
+    setFormShieldMeta,
+    getCheckOrder,
+    setCheckOrder,
+    resetCheckOrder,
     createPage,
     cleanupPages,
     getEntryNotes,

--- a/tests/E2E/mu-plugins/zs-e2e-check-order.php
+++ b/tests/E2E/mu-plugins/zs-e2e-check-order.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Plugin Name: Zero Spam E2E Check Order Seam
+ * Description: REST endpoints used by Playwright tests to seed and read the Spam Check Order plugin settings (gf_zero_spam_check_order_1..3 and gf_zero_spam_stop_after_first_detection) without going through the admin UI.
+ * Version: 1.0.0
+ *
+ * All routes require the same X-E2E-TEST-TOKEN header used by @gravitykit/e2e-fixtures
+ * so we don't introduce a second auth scheme.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const ZS_E2E_ORDER_KEYS = [
+	'gf_zero_spam_check_order_1',
+	'gf_zero_spam_check_order_2',
+	'gf_zero_spam_check_order_3',
+];
+const ZS_E2E_STOP_KEY   = 'gf_zero_spam_stop_after_first_detection';
+
+add_action(
+	'rest_api_init',
+	function () {
+		$auth = static function ( WP_REST_Request $request ) {
+			$header = (string) $request->get_header( 'X-E2E-TEST-TOKEN' );
+
+			if ( ! hash_equals( ZS_E2E_TEST_TOKEN, $header ) ) {
+				return new WP_Error( 'rest_forbidden', 'Invalid E2E token', [ 'status' => 401 ] );
+			}
+
+			return true;
+		};
+
+		$order_state_response = static function () {
+			$settings = (array) get_option( 'gravityformsaddon_gf-zero-spam_settings', [] );
+			$order    = [];
+
+			foreach ( ZS_E2E_ORDER_KEYS as $key ) {
+				$order[] = array_key_exists( $key, $settings ) ? (string) $settings[ $key ] : null;
+			}
+
+			return rest_ensure_response(
+				[
+					'order' => $order,
+					'stop'  => array_key_exists( ZS_E2E_STOP_KEY, $settings ) ? (string) $settings[ ZS_E2E_STOP_KEY ] : null,
+				]
+			);
+		};
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/check-order',
+			[
+				'methods'             => 'GET',
+				'permission_callback' => $auth,
+				'callback'            => $order_state_response,
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/check-order',
+			[
+				'methods'             => 'POST',
+				'permission_callback' => $auth,
+				'args'                => [
+					'order' => [
+						'type'     => 'array',
+						'required' => false,
+						'items'    => [ 'type' => 'string' ],
+					],
+					'stop'  => [
+						'type'     => 'boolean',
+						'required' => false,
+					],
+				],
+				'callback'            => static function ( WP_REST_Request $request ) use ( $order_state_response ) {
+					$settings = (array) get_option( 'gravityformsaddon_gf-zero-spam_settings', [] );
+
+					if ( null !== $request->get_param( 'order' ) ) {
+						$order = array_values( (array) $request->get_param( 'order' ) );
+
+						if ( 3 !== count( $order ) ) {
+							return new WP_Error( 'invalid_order', 'Order must contain exactly 3 slugs', [ 'status' => 400 ] );
+						}
+
+						foreach ( ZS_E2E_ORDER_KEYS as $index => $key ) {
+							$settings[ $key ] = (string) $order[ $index ];
+						}
+					}
+
+					if ( null !== $request->get_param( 'stop' ) ) {
+						$settings[ ZS_E2E_STOP_KEY ] = $request->get_param( 'stop' ) ? '1' : '0';
+					}
+
+					update_option( 'gravityformsaddon_gf-zero-spam_settings', $settings );
+
+					return $order_state_response();
+				},
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/check-order',
+			[
+				'methods'             => 'DELETE',
+				'permission_callback' => $auth,
+				'callback'            => static function () use ( $order_state_response ) {
+					$settings = (array) get_option( 'gravityformsaddon_gf-zero-spam_settings', [] );
+
+					foreach ( array_merge( ZS_E2E_ORDER_KEYS, [ ZS_E2E_STOP_KEY ] ) as $key ) {
+						unset( $settings[ $key ] );
+					}
+
+					update_option( 'gravityformsaddon_gf-zero-spam_settings', $settings );
+
+					return $order_state_response();
+				},
+			]
+		);
+	}
+);

--- a/tests/E2E/mu-plugins/zs-e2e-shield.php
+++ b/tests/E2E/mu-plugins/zs-e2e-shield.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Plugin Name: Zero Spam E2E Shield Mock
+ * Description: Simulates Shield Security's silentCAPTCHA callables for Playwright tests. The integration under test discovers Shield via is_callable() on the documented global-function fallbacks (shield_test_ip_is_bot, shield_get_silentcaptcha_bot_threshold), so defining them here makes Shield "available" without installing the plugin. Availability and the verdict are controlled per-test through a REST-managed option, mirroring the AI-review mock pattern in zs-e2e-helpers.php.
+ * Version: 1.0.0
+ *
+ * All routes require the same X-E2E-TEST-TOKEN header used by @gravitykit/e2e-fixtures
+ * so we don't introduce a second auth scheme.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const ZS_E2E_SHIELD_OPTION = 'zs_e2e_shield';
+
+/**
+ * Read the current Shield mock state.
+ *
+ * @return array
+ */
+function zs_e2e_shield_state() {
+	return (array) get_option( ZS_E2E_SHIELD_OPTION, [] );
+}
+
+// The integration probes is_callable() on these names, so defining them conditionally IS
+// the availability toggle. Re-evaluated every request; REST toggles apply on the next one.
+if ( ! empty( zs_e2e_shield_state()['available'] ) && ! function_exists( 'shield_test_ip_is_bot' ) ) {
+	/**
+	 * Mocked Shield bot-detection callable.
+	 *
+	 * Verdict modes: 'bot' => true, 'human' => false, 'throw' => throws,
+	 * 'garbage' => truthy non-boolean (must fail open), anything else => null.
+	 *
+	 * @throws RuntimeException When the configured verdict mode is 'throw'.
+	 *
+	 * @return mixed
+	 */
+	function shield_test_ip_is_bot() {
+		$state          = zs_e2e_shield_state();
+		$state['calls'] = (int) ( $state['calls'] ?? 0 ) + 1;
+
+		update_option( ZS_E2E_SHIELD_OPTION, $state, false );
+
+		switch ( (string) ( $state['verdict'] ?? 'null' ) ) {
+			case 'bot':
+				return true;
+			case 'human':
+				return false;
+			case 'throw':
+				throw new RuntimeException( 'E2E Shield mock failure' );
+			case 'garbage':
+				return 'yes';
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Mocked Shield silentCAPTCHA bot-threshold callable.
+	 *
+	 * @return int
+	 */
+	function shield_get_silentcaptcha_bot_threshold() {
+		$state = zs_e2e_shield_state();
+
+		return isset( $state['threshold'] ) ? (int) $state['threshold'] : 25;
+	}
+}
+
+add_action(
+	'rest_api_init',
+	function () {
+		$auth = static function ( WP_REST_Request $request ) {
+			$header = (string) $request->get_header( 'X-E2E-TEST-TOKEN' );
+
+			if ( ! hash_equals( ZS_E2E_TEST_TOKEN, $header ) ) {
+				return new WP_Error( 'rest_forbidden', 'Invalid E2E token', [ 'status' => 401 ] );
+			}
+
+			return true;
+		};
+
+		$shield_state_response = static function () {
+			$state = zs_e2e_shield_state();
+
+			return rest_ensure_response(
+				[
+					'available' => ! empty( $state['available'] ),
+					'verdict'   => (string) ( $state['verdict'] ?? 'null' ),
+					'threshold' => isset( $state['threshold'] ) ? (int) $state['threshold'] : 25,
+					'calls'     => (int) ( $state['calls'] ?? 0 ),
+				]
+			);
+		};
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/shield',
+			[
+				'methods'             => 'GET',
+				'permission_callback' => $auth,
+				'callback'            => $shield_state_response,
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/shield',
+			[
+				'methods'             => 'POST',
+				'permission_callback' => $auth,
+				'args'                => [
+					'available' => [
+						'type'     => 'boolean',
+						'required' => false,
+					],
+					'verdict'   => [
+						'type'     => 'string',
+						'required' => false,
+					],
+					'threshold' => [
+						'type'     => 'integer',
+						'required' => false,
+					],
+				],
+				'callback'            => static function ( WP_REST_Request $request ) use ( $shield_state_response ) {
+					$verdict = null === $request->get_param( 'verdict' ) ? 'null' : (string) $request->get_param( 'verdict' );
+
+					if ( ! in_array( $verdict, [ 'null', 'bot', 'human', 'throw', 'garbage' ], true ) ) {
+						return new WP_Error( 'invalid_shield_verdict', 'Invalid Shield mock verdict', [ 'status' => 400 ] );
+					}
+
+					$state = [
+						'available' => $request->get_param( 'available' ) ? true : false,
+						'verdict'   => $verdict,
+						'calls'     => 0,
+					];
+
+					if ( null !== $request->get_param( 'threshold' ) ) {
+						$state['threshold'] = (int) $request->get_param( 'threshold' );
+					}
+
+					update_option( ZS_E2E_SHIELD_OPTION, $state, false );
+
+					return $shield_state_response();
+				},
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/shield',
+			[
+				'methods'             => 'DELETE',
+				'permission_callback' => $auth,
+				'callback'            => static function () {
+					delete_option( ZS_E2E_SHIELD_OPTION );
+
+					return rest_ensure_response( [ 'reset' => true ] );
+				},
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/shield/plugin-setting',
+			[
+				'methods'             => 'GET',
+				'permission_callback' => $auth,
+				'callback'            => static function () {
+					$settings = (array) get_option( 'gravityformsaddon_gf-zero-spam_settings', [] );
+					$present  = array_key_exists( 'shield_silent_captcha', $settings );
+
+					return rest_ensure_response(
+						[
+							'present' => $present,
+							'value'   => $present ? (string) $settings['shield_silent_captcha'] : null,
+						]
+					);
+				},
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/shield/plugin-setting',
+			[
+				'methods'             => 'POST',
+				'permission_callback' => $auth,
+				'args'                => [
+					'value'  => [
+						'type'     => 'string',
+						'required' => false,
+					],
+					'remove' => [
+						'type'     => 'boolean',
+						'required' => false,
+					],
+				],
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$settings = (array) get_option( 'gravityformsaddon_gf-zero-spam_settings', [] );
+
+					if ( $request->get_param( 'remove' ) ) {
+						unset( $settings['shield_silent_captcha'] );
+					} else {
+						$settings['shield_silent_captcha'] = (string) $request->get_param( 'value' );
+					}
+
+					update_option( 'gravityformsaddon_gf-zero-spam_settings', $settings );
+
+					$present = array_key_exists( 'shield_silent_captcha', $settings );
+
+					return rest_ensure_response(
+						[
+							'present' => $present,
+							'value'   => $present ? (string) $settings['shield_silent_captcha'] : null,
+						]
+					);
+				},
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/form/(?P<form_id>\d+)/shield-meta',
+			[
+				'methods'             => 'GET',
+				'permission_callback' => $auth,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					if ( ! class_exists( 'GFFormsModel' ) ) {
+						return new WP_Error( 'gf_missing', 'Gravity Forms not loaded', [ 'status' => 500 ] );
+					}
+
+					$form = GFFormsModel::get_form_meta( (int) $request->get_param( 'form_id' ) );
+
+					if ( ! is_array( $form ) ) {
+						return new WP_Error( 'form_missing', 'Form not found', [ 'status' => 404 ] );
+					}
+
+					$present = array_key_exists( 'shield_silent_captcha', $form );
+
+					return rest_ensure_response(
+						[
+							'form_id' => (int) $request->get_param( 'form_id' ),
+							'present' => $present,
+							'value'   => $present ? (string) $form['shield_silent_captcha'] : null,
+						]
+					);
+				},
+			]
+		);
+
+		register_rest_route(
+			ZS_E2E_NAMESPACE,
+			'/form/(?P<form_id>\d+)/shield-meta',
+			[
+				'methods'             => 'POST',
+				'permission_callback' => $auth,
+				'args'                => [
+					'value'  => [
+						'type'     => 'string',
+						'required' => false,
+					],
+					'remove' => [
+						'type'     => 'boolean',
+						'required' => false,
+					],
+				],
+				'callback'            => static function ( WP_REST_Request $request ) {
+					if ( ! class_exists( 'GFAPI' ) ) {
+						return new WP_Error( 'gf_missing', 'Gravity Forms not loaded', [ 'status' => 500 ] );
+					}
+
+					$form_id = (int) $request->get_param( 'form_id' );
+					$form    = GFAPI::get_form( $form_id );
+
+					if ( ! $form ) {
+						return new WP_Error( 'form_missing', 'Form not found', [ 'status' => 404 ] );
+					}
+
+					if ( $request->get_param( 'remove' ) ) {
+						unset( $form['shield_silent_captcha'] );
+					} else {
+						$form['shield_silent_captcha'] = (string) $request->get_param( 'value' );
+					}
+
+					$result = GFAPI::update_form( $form );
+
+					if ( is_wp_error( $result ) ) {
+						return $result;
+					}
+
+					$present = array_key_exists( 'shield_silent_captcha', $form );
+
+					return rest_ensure_response(
+						[
+							'form_id' => $form_id,
+							'present' => $present,
+							'value'   => $present ? (string) $form['shield_silent_captcha'] : null,
+						]
+					);
+				},
+			]
+		);
+	}
+);

--- a/tests/E2E/setup/zs-e2e-loader.php
+++ b/tests/E2E/setup/zs-e2e-loader.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $zs_e2e_dir = WPMU_PLUGIN_DIR . '/zs-e2e';
 
 if ( is_dir( $zs_e2e_dir ) ) {
-	foreach ( [ 'zs-e2e-mailcatch.php', 'zs-e2e-helpers.php' ] as $file ) {
+	foreach ( [ 'zs-e2e-mailcatch.php', 'zs-e2e-helpers.php', 'zs-e2e-shield.php', 'zs-e2e-check-order.php' ] as $file ) {
 		$zs_e2e_path = $zs_e2e_dir . '/' . $file;
 
 		if ( file_exists( $zs_e2e_path ) ) {

--- a/tests/E2E/tests/09-shield-absent.spec.js
+++ b/tests/E2E/tests/09-shield-absent.spec.js
@@ -56,7 +56,7 @@ test.describe('Shield silentCAPTCHA — Shield absent', () => {
 
         const learnMore = page.locator('a', { hasText: 'Learn More' }).first();
         await expect(learnMore).toBeVisible();
-        await expect(learnMore).toHaveAttribute('href', /gravitykit\.com\/zero-spam-shield-silentcaptcha/);
+        await expect(learnMore).toHaveAttribute('href', /gravitykit\.com\/docs\/gravity-forms-zero-spam\/shield-silentcaptcha/);
     });
 
     test('HP-61: saving plugin settings while Shield is absent preserves the stored value', async ({

--- a/tests/E2E/tests/09-shield-absent.spec.js
+++ b/tests/E2E/tests/09-shield-absent.spec.js
@@ -1,0 +1,173 @@
+/**
+ * Zero Spam — Shield silentCAPTCHA with Shield ABSENT (HP-60 through HP-63).
+ *
+ * This is the default CI state: the Shield Security plugin is not installed,
+ * so the integration must render disabled controls, never wipe stored values
+ * on save (a disabled toggle posts nothing, which is indistinguishable from an
+ * uncheck), preserve per-form inheritance, and fail open on submissions even
+ * when the setting is enabled.
+ *
+ * Selectors (same GF Settings framework as 02-form-toggles):
+ *   - Toggle input:   input#_gform_setting_shield_silent_captcha (checkbox).
+ *   - Save button:    #gform-settings-save.
+ *   - Success notice: .alert.gforms_note_success → "Settings updated."
+ */
+
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+const helpers = require('../helpers');
+
+// Mutates the global Shield plugin setting; keep tests in this file ordered.
+test.describe.configure({ mode: 'serial' });
+
+const SHIELD_TOGGLE = '#_gform_setting_shield_silent_captcha';
+const SAVE_BUTTON = '#gform-settings-save';
+const SUCCESS_NOTICE = '.alert.gforms_note_success';
+const UNAVAILABLE_TEXT =
+    'Shield silentCAPTCHA is currently unavailable because Shield Security is not installed or active.';
+
+const PLUGIN_SETTINGS_URL = '/wp-admin/admin.php?page=gf_settings&subview=gf-zero-spam';
+
+function formSettingsUrl(formId) {
+    return `/wp-admin/admin.php?page=gf_edit_forms&view=settings&id=${formId}`;
+}
+
+test.describe('Shield silentCAPTCHA — Shield absent', () => {
+    test.beforeEach(async ({ request }) => {
+        // Defensive: make sure a previous run's mock isn't leaving Shield "installed".
+        await helpers.resetShieldMock(request);
+    });
+
+    test.afterEach(async ({ request }) => {
+        await helpers.setShieldPluginSetting(request, { remove: true });
+        await helpers.resetShieldMock(request);
+    });
+
+    test('HP-60: plugin settings render a disabled Shield toggle with the unavailable message', async ({
+        page,
+    }) => {
+        await page.goto(PLUGIN_SETTINGS_URL);
+
+        const toggle = page.locator(SHIELD_TOGGLE);
+        await expect(toggle, 'Shield toggle must render').toHaveCount(1);
+        await expect(toggle, 'Shield toggle must be disabled when Shield is absent').toBeDisabled();
+        await expect(toggle, 'default stored value is off').not.toBeChecked();
+
+        await expect(page.locator(`text=${UNAVAILABLE_TEXT}`)).toBeVisible();
+
+        const learnMore = page.locator('a', { hasText: 'Learn More' }).first();
+        await expect(learnMore).toBeVisible();
+        await expect(learnMore).toHaveAttribute('href', /gravitykit\.com\/zero-spam-shield-silentcaptcha/);
+    });
+
+    test('HP-61: saving plugin settings while Shield is absent preserves the stored value', async ({
+        page,
+        request,
+    }) => {
+        // A site enabled Shield, then deactivated the Shield plugin. Saving the
+        // Zero Spam settings page must NOT wipe the stored '1' to '0'.
+        await helpers.setShieldPluginSetting(request, { value: '1' });
+
+        await page.goto(PLUGIN_SETTINGS_URL);
+
+        const toggle = page.locator(SHIELD_TOGGLE);
+        await expect(toggle).toBeDisabled();
+        await expect(toggle, 'stored value must render as checked even while disabled').toBeChecked();
+
+        await page.locator(SAVE_BUTTON).click();
+        await expect(page.locator(SUCCESS_NOTICE)).toContainText('Settings updated.');
+
+        const stored = await helpers.getShieldPluginSetting(request);
+        expect(stored.present, 'stored Shield setting must survive the save').toBe(true);
+        expect(stored.value, 'disabled toggle must not wipe the stored value to 0').toBe('1');
+
+        // The save postback re-renders from POSTed values, where the disabled
+        // toggle posted nothing, so it briefly renders unchecked. The durable
+        // state is what a fresh page load renders.
+        await page.reload();
+        await expect(page.locator(SHIELD_TOGGLE)).toBeChecked();
+    });
+
+    test('HP-62: form settings render a disabled Shield toggle and an untouched save keeps inheriting', async ({
+        page,
+        request,
+    }) => {
+        const data = await helpers.createFromTemplate({
+            template: 'simple',
+            skipView: true,
+        });
+
+        try {
+            await page.goto(formSettingsUrl(data.form_id));
+
+            const toggle = page.locator(SHIELD_TOGGLE);
+            await expect(toggle, 'per-form Shield toggle must render').toHaveCount(1);
+            await expect(toggle, 'per-form Shield toggle must be disabled when Shield is absent').toBeDisabled();
+
+            await page.locator(SAVE_BUTTON).click();
+            await expect(page.locator(SUCCESS_NOTICE)).toContainText('Settings updated.');
+
+            const meta = await helpers.getFormShieldMeta(request, data.form_id);
+            expect(
+                meta.present,
+                'untouched save must not materialize a per-form Shield override'
+            ).toBe(false);
+        } finally {
+            await helpers.cleanup(data.test_id);
+        }
+    });
+
+    test('HP-63: submission passes when Shield is enabled but absent (fail-open smoke)', async ({
+        request,
+        browser,
+    }) => {
+        // Worst case for fail-open: the setting says ON but Shield is gone.
+        await helpers.setShieldPluginSetting(request, { value: '1' });
+
+        const data = await helpers.createFromTemplate({
+            template: 'simple',
+            skipView: true,
+        });
+        const created = await helpers.createPage(request, {
+            title: `ZS Shield Absent ${data.test_id}`,
+            content: `[gravityform id="${data.form_id}" title="false" description="false" ajax="false"]`,
+            slug: `zs-shield-absent-${data.test_id}`,
+        });
+
+        // Token protection ON like HP-1: a real browser passes the token check,
+        // then the Shield hook runs — and must be a no-op without Shield.
+        await helpers.setFormZeroSpam(request, data.form_id, true);
+
+        const anonContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
+        });
+        const anonPage = await anonContext.newPage();
+        const email = `shield-absent+${data.test_id}@gravitykit.test`;
+
+        try {
+            await anonPage.goto(created.permalink);
+            await anonPage
+                .locator(`#gform_${data.form_id} input[name="input_1"]`)
+                .fill('Alice');
+            await anonPage
+                .locator(`#gform_${data.form_id} input[name="input_2"]`)
+                .fill(email);
+            await anonPage.locator(`#gform_submit_button_${data.form_id}`).click();
+
+            await expect(
+                anonPage.locator(`#gform_confirmation_wrapper_${data.form_id}`)
+            ).toContainText('Thanks for contacting us!');
+
+            const active = await helpers.getEntries(request, data.form_id, 'active');
+            const submitted = active.filter((entry) => entry['2'] === email);
+            expect(submitted, 'submission must land as an active entry').toHaveLength(1);
+
+            const spam = await helpers.getEntries(request, data.form_id, 'spam');
+            const leaked = spam.filter((entry) => entry['2'] === email);
+            expect(leaked, 'Shield-absent must never flag spam').toHaveLength(0);
+        } finally {
+            await anonContext.close();
+            await helpers.cleanup(data.test_id);
+            await helpers.cleanupPages(request, [created.page_id]);
+        }
+    });
+});

--- a/tests/E2E/tests/10-shield-mocked.spec.js
+++ b/tests/E2E/tests/10-shield-mocked.spec.js
@@ -306,14 +306,17 @@ test.describe('Shield silentCAPTCHA — submissions with Shield available', () =
                 const spam = await helpers.getEntries(request, formId, 'spam');
                 const leaked = spam.filter((entry) => entry['2'] === email);
                 expect(leaked, `${verdict}: must never be flagged as spam`).toHaveLength(0);
+
+                // setShieldMock() resets the counter each iteration, so assert per
+                // verdict that fail-open passed through Shield rather than skipping it.
+                const mock = await helpers.getShieldMock(request);
+                expect(
+                    mock.calls,
+                    `${verdict}: the Shield callable must have been consulted`
+                ).toBeGreaterThan(0);
             }
         } finally {
             await anonContext.close();
         }
-
-        // 'human' and 'garbage' reach the callable; 'throw' increments before
-        // throwing — all three must have consulted the mock.
-        const mock = await helpers.getShieldMock(request);
-        expect(mock.calls, 'the thrown-error run must still have called the mock').toBeGreaterThan(0);
     });
 });

--- a/tests/E2E/tests/10-shield-mocked.spec.js
+++ b/tests/E2E/tests/10-shield-mocked.spec.js
@@ -1,0 +1,319 @@
+/**
+ * Zero Spam — Shield silentCAPTCHA with Shield MOCKED (HP-64 through HP-68).
+ *
+ * Uses tests/E2E/mu-plugins/zs-e2e-shield.php, which defines the integration's
+ * documented global-function fallbacks (shield_test_ip_is_bot,
+ * shield_get_silentcaptcha_bot_threshold) so the integration sees Shield as
+ * installed, with a REST-controlled verdict per test.
+ *
+ * Contracts under test:
+ *   - Global toggle: check → '1', uncheck → '0' (an unchecked enabled toggle
+ *     posts nothing and must resolve to OFF, not resurrect the old value).
+ *   - Per-form: an untouched save must keep the form meta key ABSENT so the
+ *     form keeps inheriting the global default; an explicit uncheck stores '0'.
+ *   - Runtime: only a strict boolean true verdict flags spam (with Shield
+ *     attribution on the entry); false, garbage, and thrown errors fail open.
+ */
+
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+const helpers = require('../helpers');
+
+// Mutates the global Shield plugin setting and the shared mock option.
+test.describe.configure({ mode: 'serial' });
+
+const SHIELD_TOGGLE = '#_gform_setting_shield_silent_captcha';
+const SHIELD_TOGGLE_LABEL = `label.gform-field__toggle-container[for="_gform_setting_shield_silent_captcha"]`;
+const SAVE_BUTTON = '#gform-settings-save';
+const SUCCESS_NOTICE = '.alert.gforms_note_success';
+
+const PLUGIN_SETTINGS_URL = '/wp-admin/admin.php?page=gf_settings&subview=gf-zero-spam';
+
+function formSettingsUrl(formId) {
+    return `/wp-admin/admin.php?page=gf_edit_forms&view=settings&id=${formId}`;
+}
+
+async function saveAndWait(page) {
+    await page.locator(SAVE_BUTTON).click();
+    await expect(page.locator(SUCCESS_NOTICE)).toContainText('Settings updated.');
+}
+
+test.describe('Shield silentCAPTCHA — settings with Shield available', () => {
+    test.beforeEach(async ({ request }) => {
+        await helpers.setShieldMock(request, { available: true });
+        await helpers.setShieldPluginSetting(request, { remove: true });
+    });
+
+    test.afterEach(async ({ request }) => {
+        await helpers.setShieldPluginSetting(request, { remove: true });
+        await helpers.resetShieldMock(request);
+    });
+
+    test('HP-64: global toggle saves ON as 1 and a later uncheck saves 0', async ({
+        page,
+        request,
+    }) => {
+        await page.goto(PLUGIN_SETTINGS_URL);
+
+        const toggle = page.locator(SHIELD_TOGGLE);
+        await expect(toggle, 'toggle must be interactive when Shield is available').toBeEnabled();
+        await expect(toggle).not.toBeChecked();
+
+        await page.locator(SHIELD_TOGGLE_LABEL).click();
+        await expect(toggle).toBeChecked();
+        await saveAndWait(page);
+
+        let stored = await helpers.getShieldPluginSetting(request);
+        expect(stored.present).toBe(true);
+        expect(stored.value, 'checked toggle must persist as 1').toBe('1');
+        await expect(page.locator(SHIELD_TOGGLE)).toBeChecked();
+
+        await page.locator(SHIELD_TOGGLE_LABEL).click();
+        await expect(page.locator(SHIELD_TOGGLE)).not.toBeChecked();
+        await saveAndWait(page);
+
+        stored = await helpers.getShieldPluginSetting(request);
+        expect(stored.present).toBe(true);
+        expect(stored.value, 'unchecked toggle must persist as 0, not resurrect 1').toBe('0');
+        await expect(page.locator(SHIELD_TOGGLE)).not.toBeChecked();
+    });
+
+    test('HP-65: an untouched form settings save keeps the form inheriting the global default', async ({
+        page,
+        request,
+    }) => {
+        const data = await helpers.createFromTemplate({
+            template: 'simple',
+            skipView: true,
+        });
+
+        try {
+            // Global ON: the inherited toggle renders checked, and GF materializes
+            // that value into the posted settings — the save must still not write
+            // a per-form override.
+            await helpers.setShieldPluginSetting(request, { value: '1' });
+
+            await page.goto(formSettingsUrl(data.form_id));
+            await expect(page.locator(SHIELD_TOGGLE)).toBeEnabled();
+            await expect(
+                page.locator(SHIELD_TOGGLE),
+                'inheriting form must render the global default'
+            ).toBeChecked();
+
+            await saveAndWait(page);
+
+            let meta = await helpers.getFormShieldMeta(request, data.form_id);
+            expect(
+                meta.present,
+                'untouched save under global ON must keep the meta key absent'
+            ).toBe(false);
+
+            // Global OFF: the unchecked toggle posts nothing, which must not be
+            // mistaken for a deliberate uncheck on an inheriting form.
+            await helpers.setShieldPluginSetting(request, { value: '0' });
+
+            await page.goto(formSettingsUrl(data.form_id));
+            await expect(page.locator(SHIELD_TOGGLE)).not.toBeChecked();
+
+            await saveAndWait(page);
+
+            meta = await helpers.getFormShieldMeta(request, data.form_id);
+            expect(
+                meta.present,
+                'untouched save under global OFF must keep the meta key absent'
+            ).toBe(false);
+        } finally {
+            await helpers.cleanup(data.test_id);
+        }
+    });
+
+    test('HP-66: a per-form override saves 1, and unchecking it saves 0', async ({
+        page,
+        request,
+    }) => {
+        await helpers.setShieldPluginSetting(request, { value: '0' });
+
+        const data = await helpers.createFromTemplate({
+            template: 'simple',
+            skipView: true,
+        });
+
+        try {
+            await page.goto(formSettingsUrl(data.form_id));
+            await expect(page.locator(SHIELD_TOGGLE)).not.toBeChecked();
+
+            await page.locator(SHIELD_TOGGLE_LABEL).click();
+            await expect(page.locator(SHIELD_TOGGLE)).toBeChecked();
+            await saveAndWait(page);
+
+            let meta = await helpers.getFormShieldMeta(request, data.form_id);
+            expect(meta.present, 'checking the toggle must write an override').toBe(true);
+            expect(meta.value).toBe('1');
+
+            await page.goto(formSettingsUrl(data.form_id));
+            await expect(page.locator(SHIELD_TOGGLE)).toBeChecked();
+
+            await page.locator(SHIELD_TOGGLE_LABEL).click();
+            await expect(page.locator(SHIELD_TOGGLE)).not.toBeChecked();
+            await saveAndWait(page);
+
+            meta = await helpers.getFormShieldMeta(request, data.form_id);
+            expect(meta.present, 'the override must remain explicit after unchecking').toBe(true);
+            expect(meta.value, 'unchecking an override must store 0, not resurrect 1').toBe('0');
+        } finally {
+            await helpers.cleanup(data.test_id);
+        }
+    });
+});
+
+test.describe('Shield silentCAPTCHA — submissions with Shield available', () => {
+    let formId;
+    let pageId;
+    let pageUrl;
+    let testId;
+
+    test.beforeEach(async ({ request }) => {
+        await helpers.setShieldPluginSetting(request, { remove: true });
+
+        const data = await helpers.createFromTemplate({
+            template: 'simple',
+            skipView: true,
+        });
+        formId = data.form_id;
+        testId = data.test_id;
+
+        // Zero Spam explicitly ON: it is now the master gate for the whole
+        // pipeline, Shield included, so it can no longer be disabled to isolate
+        // Shield. The browser flow submits a valid token, so the token check
+        // passes and Shield still decides alone.
+        await helpers.setFormZeroSpam(request, formId, true);
+
+        const created = await helpers.createPage(request, {
+            title: `ZS Shield Mock ${testId}`,
+            content: `[gravityform id="${formId}" title="false" description="false" ajax="false"]`,
+            slug: `zs-shield-mock-${testId}`,
+        });
+        pageId = created.page_id;
+        pageUrl = created.permalink;
+    });
+
+    test.afterEach(async ({ request }) => {
+        await helpers.resetShieldMock(request);
+        await helpers.setShieldPluginSetting(request, { remove: true });
+        await helpers.cleanup(testId);
+        await helpers.cleanupPages(request, [pageId]);
+    });
+
+    test('HP-67: a bot verdict sends the entry to spam with Shield attribution', async ({
+        request,
+        browser,
+    }) => {
+        // The form has no override, so the flag must arrive via inheritance
+        // from the global default.
+        await helpers.setShieldPluginSetting(request, { value: '1' });
+        await helpers.setShieldMock(request, { available: true, verdict: 'bot' });
+
+        const anonContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
+        });
+        const anonPage = await anonContext.newPage();
+        const email = `shield-bot+${testId}@gravitykit.test`;
+
+        try {
+            await anonPage.goto(pageUrl);
+            await anonPage.locator(`#gform_${formId} input[name="input_1"]`).fill('Botty');
+            await anonPage.locator(`#gform_${formId} input[name="input_2"]`).fill(email);
+            await anonPage.locator(`#gform_submit_button_${formId}`).click();
+
+            // Spam entries still show the confirmation: the submitter must not
+            // learn they were flagged.
+            await expect(
+                anonPage.locator(`#gform_confirmation_wrapper_${formId}`)
+            ).toContainText('Thanks for contacting us!');
+        } finally {
+            await anonContext.close();
+        }
+
+        const spam = await helpers.getEntries(request, formId, 'spam');
+        const trapped = spam.filter((entry) => entry['2'] === email);
+        expect(trapped, 'bot verdict must produce a spam entry').toHaveLength(1);
+
+        const active = await helpers.getEntries(request, formId, 'active');
+        const leaked = active.filter((entry) => entry['2'] === email);
+        expect(leaked, 'bot verdict must not produce an active entry').toHaveLength(0);
+
+        const notes = await helpers.getEntryNotes(request, Number(trapped[0].id));
+        expect(
+            notes.some((note) => note.user_name === 'Shield silentCAPTCHA'),
+            'spam note must be attributed to Shield silentCAPTCHA'
+        ).toBe(true);
+        expect(
+            notes.some((note) => note.value.includes('Shield silentCAPTCHA')),
+            'spam note must name the Shield filter in its reason'
+        ).toBe(true);
+
+        const mock = await helpers.getShieldMock(request);
+        expect(mock.calls, 'the Shield callable must have been consulted').toBeGreaterThan(0);
+    });
+
+    test('HP-68: non-true verdicts (human, garbage, thrown error) all fail open', async ({
+        request,
+        browser,
+    }) => {
+        await helpers.setFormShieldMeta(request, formId, { value: '1' });
+
+        const anonContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
+        });
+        const anonPage = await anonContext.newPage();
+
+        try {
+            await anonPage.goto(pageUrl);
+
+            for (const verdict of ['human', 'garbage', 'throw']) {
+                await helpers.setShieldMock(request, { available: true, verdict });
+
+                const email = `shield-${verdict}+${testId}@gravitykit.test`;
+                // Zero Spam is ON (master gate), so this programmatic POST needs
+                // a valid token; the async JS injection is not awaited here.
+                const token = await helpers.mintToken(request, formId);
+                const result = await anonPage.evaluate(
+                    async ({ id, submittedEmail, token }) => {
+                        const form = document.getElementById('gform_' + id);
+                        const fd = new FormData(form);
+                        fd.set('input_1', 'Visitor');
+                        fd.set('input_2', submittedEmail);
+                        fd.set('gf_zero_spam_token', token);
+
+                        const res = await fetch(form.action || location.href, {
+                            method: 'POST',
+                            body: fd,
+                            redirect: 'follow',
+                        });
+
+                        return { status: res.status };
+                    },
+                    { id: formId, submittedEmail: email, token }
+                );
+                expect(result.status, `${verdict}: POST must succeed`).toBe(200);
+
+                const active = await helpers.getEntries(request, formId, 'active');
+                const submitted = active.filter((entry) => entry['2'] === email);
+                expect(
+                    submitted,
+                    `${verdict}: submission must land as an active entry`
+                ).toHaveLength(1);
+
+                const spam = await helpers.getEntries(request, formId, 'spam');
+                const leaked = spam.filter((entry) => entry['2'] === email);
+                expect(leaked, `${verdict}: must never be flagged as spam`).toHaveLength(0);
+            }
+        } finally {
+            await anonContext.close();
+        }
+
+        // 'human' and 'garbage' reach the callable; 'throw' increments before
+        // throwing — all three must have consulted the mock.
+        const mock = await helpers.getShieldMock(request);
+        expect(mock.calls, 'the thrown-error run must still have called the mock').toBeGreaterThan(0);
+    });
+});

--- a/tests/E2E/tests/11-check-order.spec.js
+++ b/tests/E2E/tests/11-check-order.spec.js
@@ -1,0 +1,422 @@
+/**
+ * Zero Spam — Spam Check Order & per-form master gate (HP-69 through HP-74).
+ *
+ * Uses the Shield mock (tests/E2E/mu-plugins/zs-e2e-shield.php) and the
+ * check-order seam (tests/E2E/mu-plugins/zs-e2e-check-order.php).
+ *
+ * Contracts under test:
+ *   - The configured order decides which check flags first and gets the spam
+ *     attribution; with "Stop after first detection" ON, later checks never
+ *     run (the Shield callable is not even consulted).
+ *   - Stop OFF: later checks still evaluate and record verdict notes on the
+ *     flagged entry, without ever clearing the spam status.
+ *   - The per-form Zero Spam toggle master-gates the pipeline: runtime checks
+ *     are skipped and the Shield/AI form fields are dependency-hidden, while
+ *     stored Shield values survive saves made in that state.
+ *   - Order settings UI: saves round-trip; a duplicated selection falls back
+ *     to the default order; the order survives saves while Shield is absent.
+ */
+
+const { test, expect } = require('@wordpress/e2e-test-utils-playwright');
+const helpers = require('../helpers');
+
+// Mutates global plugin settings (order, stop, Shield default) and the mock.
+test.describe.configure({ mode: 'serial' });
+
+// GF Select fields use the bare field name as the id (no _gform_setting_ prefix, unlike toggles).
+const ORDER_SELECT_1 = '#gf_zero_spam_check_order_1';
+const ORDER_SELECT_2 = '#gf_zero_spam_check_order_2';
+const ORDER_SELECT_3 = '#gf_zero_spam_check_order_3';
+const STOP_TOGGLE = '#_gform_setting_gf_zero_spam_stop_after_first_detection';
+const MASTER_TOGGLE = '#_gform_setting_enableGFZeroSpam';
+const MASTER_TOGGLE_LABEL = `label[for="_gform_setting_enableGFZeroSpam"]`;
+const SHIELD_TOGGLE = '#_gform_setting_shield_silent_captcha';
+const AI_TOGGLE = '#_gform_setting_enableGFZeroSpamAI';
+const SAVE_BUTTON = '#gform-settings-save';
+const SUCCESS_NOTICE = '.alert.gforms_note_success';
+const SHIELD_SKIPPED_TEXT = 'Shield Security is not active — this check is skipped.';
+
+const PLUGIN_SETTINGS_URL = '/wp-admin/admin.php?page=gf_settings&subview=gf-zero-spam';
+
+function formSettingsUrl(formId) {
+    return `/wp-admin/admin.php?page=gf_edit_forms&view=settings&id=${formId}`;
+}
+
+async function saveAndWait(page) {
+    await page.locator(SAVE_BUTTON).click();
+    await expect(page.locator(SUCCESS_NOTICE)).toContainText('Settings updated.');
+}
+
+// POSTs the already-rendered form with a deliberately invalid token so the
+// token check produces a spam verdict without the JS submission path.
+async function postWithInvalidToken(page, formId, email) {
+    return page.evaluate(
+        async ({ id, submittedEmail }) => {
+            const form = document.getElementById('gform_' + id);
+            const fd = new FormData(form);
+            fd.set('input_1', 'Botty');
+            fd.set('input_2', submittedEmail);
+            fd.set('gf_zero_spam_token', 'not-a-valid-zero-spam-token');
+            fd.delete('gf_zero_spam_key');
+
+            const res = await fetch(form.action || location.href, {
+                method: 'POST',
+                body: fd,
+                redirect: 'follow',
+            });
+
+            return { status: res.status };
+        },
+        { id: formId, submittedEmail: email }
+    );
+}
+
+async function getSpamEntryFor(request, formId, email) {
+    const spam = await helpers.getEntries(request, formId, 'spam');
+    const matched = spam.filter((entry) => entry['2'] === email);
+    expect(matched, `spam entry expected for ${email}`).toHaveLength(1);
+
+    return matched[0];
+}
+
+test.describe('Spam check order — runtime attribution and stop toggle', () => {
+    let formId;
+    let pageId;
+    let pageUrl;
+    let testId;
+
+    test.beforeEach(async ({ request }) => {
+        await helpers.resetCheckOrder(request);
+        await helpers.setShieldPluginSetting(request, { value: '1' });
+        await helpers.setShieldMock(request, { available: true, verdict: 'bot' });
+
+        const data = await helpers.createFromTemplate({
+            template: 'simple',
+            skipView: true,
+        });
+        formId = data.form_id;
+        testId = data.test_id;
+
+        await helpers.setFormZeroSpam(request, formId, true);
+
+        const created = await helpers.createPage(request, {
+            title: `ZS Check Order ${testId}`,
+            content: `[gravityform id="${formId}" title="false" description="false" ajax="false"]`,
+            slug: `zs-check-order-${testId}`,
+        });
+        pageId = created.page_id;
+        pageUrl = created.permalink;
+    });
+
+    test.afterEach(async ({ request }) => {
+        await helpers.resetCheckOrder(request);
+        await helpers.resetShieldMock(request);
+        await helpers.setShieldPluginSetting(request, { remove: true });
+        await helpers.cleanup(testId);
+        await helpers.cleanupPages(request, [pageId]);
+    });
+
+    test('HP-69: the configured order decides which check attributes the spam', async ({
+        request,
+        browser,
+    }) => {
+        const anonContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
+        });
+        const anonPage = await anonContext.newPage();
+
+        try {
+            await anonPage.goto(pageUrl);
+
+            // Default order (token first): the token check flags and, with stop
+            // ON (default), the Shield callable must never even be consulted.
+            const tokenFirstEmail = `order-token-first+${testId}@gravitykit.test`;
+            const first = await postWithInvalidToken(anonPage, formId, tokenFirstEmail);
+            expect(first.status).toBe(200);
+
+            const tokenEntry = await getSpamEntryFor(request, formId, tokenFirstEmail);
+            const tokenNotes = await helpers.getEntryNotes(request, Number(tokenEntry.id));
+            expect(
+                tokenNotes.some((note) => note.user_name === 'Zero Spam'),
+                'token-first order must attribute the spam to Zero Spam'
+            ).toBe(true);
+            expect(
+                tokenNotes.some((note) => note.user_name === 'Shield silentCAPTCHA'),
+                'stop ON must leave no Shield note'
+            ).toBe(false);
+
+            let mock = await helpers.getShieldMock(request);
+            expect(
+                mock.calls,
+                'stop ON must skip Shield entirely after the token flags'
+            ).toBe(0);
+
+            // Shield first: Shield flags at the first slot and the token check,
+            // seeing a flagged entry with stop ON, stays silent.
+            await helpers.setCheckOrder(request, { order: ['shield', 'token', 'ai'] });
+
+            const shieldFirstEmail = `order-shield-first+${testId}@gravitykit.test`;
+            const second = await postWithInvalidToken(anonPage, formId, shieldFirstEmail);
+            expect(second.status).toBe(200);
+
+            const shieldEntry = await getSpamEntryFor(request, formId, shieldFirstEmail);
+            const shieldNotes = await helpers.getEntryNotes(request, Number(shieldEntry.id));
+            expect(
+                shieldNotes.some((note) => note.user_name === 'Shield silentCAPTCHA'),
+                'shield-first order must attribute the spam to Shield'
+            ).toBe(true);
+            expect(
+                shieldNotes.some((note) => note.user_name === 'Zero Spam'),
+                'stop ON must leave no token note on a Shield-flagged entry'
+            ).toBe(false);
+
+            mock = await helpers.getShieldMock(request);
+            expect(mock.calls, 'shield-first order must consult the callable').toBeGreaterThan(0);
+        } finally {
+            await anonContext.close();
+        }
+    });
+
+    test('HP-70: stop OFF records every check verdict as a note on the flagged entry', async ({
+        request,
+        browser,
+    }) => {
+        await helpers.setCheckOrder(request, { stop: false });
+
+        const anonContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
+        });
+        const anonPage = await anonContext.newPage();
+
+        try {
+            await anonPage.goto(pageUrl);
+
+            // Token first: token flags, Shield still evaluates and records its
+            // agreeing verdict as a secondary note.
+            const tokenFirstEmail = `stopoff-token-first+${testId}@gravitykit.test`;
+            const first = await postWithInvalidToken(anonPage, formId, tokenFirstEmail);
+            expect(first.status).toBe(200);
+
+            const tokenEntry = await getSpamEntryFor(request, formId, tokenFirstEmail);
+            const tokenNotes = await helpers.getEntryNotes(request, Number(tokenEntry.id));
+            expect(
+                tokenNotes.some((note) => note.user_name === 'Zero Spam'),
+                'token attribution note must be present'
+            ).toBe(true);
+            expect(
+                tokenNotes.some(
+                    (note) =>
+                        note.user_name === 'Shield silentCAPTCHA' &&
+                        note.value.includes('also identified this submission as spam')
+                ),
+                'Shield must record its agreeing verdict as a note'
+            ).toBe(true);
+
+            const mock = await helpers.getShieldMock(request);
+            expect(mock.calls, 'stop OFF must still consult Shield').toBeGreaterThan(0);
+
+            // Shield first: Shield flags, the token check still evaluates and
+            // records its agreeing verdict as a secondary note.
+            await helpers.setCheckOrder(request, {
+                order: ['shield', 'token', 'ai'],
+                stop: false,
+            });
+
+            const shieldFirstEmail = `stopoff-shield-first+${testId}@gravitykit.test`;
+            const second = await postWithInvalidToken(anonPage, formId, shieldFirstEmail);
+            expect(second.status).toBe(200);
+
+            const shieldEntry = await getSpamEntryFor(request, formId, shieldFirstEmail);
+            const shieldNotes = await helpers.getEntryNotes(request, Number(shieldEntry.id));
+            expect(
+                shieldNotes.some((note) => note.user_name === 'Shield silentCAPTCHA'),
+                'Shield attribution note must be present'
+            ).toBe(true);
+            expect(
+                shieldNotes.some(
+                    (note) =>
+                        note.user_name === 'Zero Spam' &&
+                        note.value.includes('also flagged this submission')
+                ),
+                'the token check must record its agreeing verdict as a note'
+            ).toBe(true);
+        } finally {
+            await anonContext.close();
+        }
+    });
+
+    test('HP-71: the per-form Zero Spam toggle master-gates Shield at runtime', async ({
+        request,
+        browser,
+    }) => {
+        await helpers.setFormZeroSpam(request, formId, false);
+
+        const anonContext = await browser.newContext({
+            storageState: { cookies: [], origins: [] },
+        });
+        const anonPage = await anonContext.newPage();
+        const email = `master-gate+${testId}@gravitykit.test`;
+
+        try {
+            await anonPage.goto(pageUrl);
+
+            // Tokenless POST with a bot verdict staged: with the master gate
+            // off, neither the token check nor Shield may flag it.
+            const result = await anonPage.evaluate(
+                async ({ id, submittedEmail }) => {
+                    const form = document.getElementById('gform_' + id);
+                    const fd = new FormData(form);
+                    fd.set('input_1', 'Visitor');
+                    fd.set('input_2', submittedEmail);
+                    fd.delete('gf_zero_spam_token');
+                    fd.delete('gf_zero_spam_key');
+
+                    const res = await fetch(form.action || location.href, {
+                        method: 'POST',
+                        body: fd,
+                        redirect: 'follow',
+                    });
+
+                    return { status: res.status };
+                },
+                { id: formId, submittedEmail: email }
+            );
+            expect(result.status).toBe(200);
+        } finally {
+            await anonContext.close();
+        }
+
+        const active = await helpers.getEntries(request, formId, 'active');
+        const submitted = active.filter((entry) => entry['2'] === email);
+        expect(submitted, 'gated submission must land as an active entry').toHaveLength(1);
+
+        const spam = await helpers.getEntries(request, formId, 'spam');
+        const leaked = spam.filter((entry) => entry['2'] === email);
+        expect(leaked, 'no check may flag while the master gate is off').toHaveLength(0);
+
+        const mock = await helpers.getShieldMock(request);
+        expect(mock.calls, 'the Shield callable must never be consulted').toBe(0);
+    });
+
+    test('HP-72: the master toggle hides the Shield and AI fields and preserves stored Shield values', async ({
+        page,
+        request,
+    }) => {
+        await helpers.setFormShieldMeta(request, formId, { value: '1' });
+
+        await page.goto(formSettingsUrl(formId));
+
+        await expect(page.locator(MASTER_TOGGLE)).toBeChecked();
+        await expect(page.locator(SHIELD_TOGGLE)).toBeVisible();
+        await expect(page.locator(AI_TOGGLE)).toBeVisible();
+
+        await page.locator(MASTER_TOGGLE_LABEL).click();
+        await expect(page.locator(MASTER_TOGGLE)).not.toBeChecked();
+        await expect(
+            page.locator(SHIELD_TOGGLE),
+            'Shield field must live-hide when the master toggle is off'
+        ).toBeHidden();
+        await expect(
+            page.locator(AI_TOGGLE),
+            'AI field must live-hide when the master toggle is off'
+        ).toBeHidden();
+
+        await saveAndWait(page);
+
+        const meta = await helpers.getFormShieldMeta(request, formId);
+        expect(meta.present, 'stored Shield override must survive a master-off save').toBe(true);
+        expect(meta.value, 'stored Shield override value must be preserved').toBe('1');
+
+        await page.reload();
+        await expect(page.locator(MASTER_TOGGLE)).not.toBeChecked();
+        await expect(page.locator(SHIELD_TOGGLE)).toBeHidden();
+
+        // Re-enabling the master toggle brings the preserved state back.
+        await page.locator(MASTER_TOGGLE_LABEL).click();
+        await expect(page.locator(SHIELD_TOGGLE)).toBeVisible();
+        await expect(page.locator(SHIELD_TOGGLE)).toBeChecked();
+    });
+});
+
+test.describe('Spam check order — settings UI', () => {
+    test.beforeEach(async ({ request }) => {
+        await helpers.resetCheckOrder(request);
+        await helpers.setShieldMock(request, { available: true });
+    });
+
+    test.afterEach(async ({ request }) => {
+        await helpers.resetCheckOrder(request);
+        await helpers.resetShieldMock(request);
+    });
+
+    test('HP-73: reordering saves and round-trips; duplicate selections fall back to the default order', async ({
+        page,
+        request,
+    }) => {
+        await page.goto(PLUGIN_SETTINGS_URL);
+
+        await expect(page.locator(ORDER_SELECT_1)).toHaveValue('token');
+        await expect(page.locator(ORDER_SELECT_2)).toHaveValue('shield');
+        await expect(page.locator(ORDER_SELECT_3)).toHaveValue('ai');
+        await expect(page.locator(STOP_TOGGLE), 'stop defaults to ON').toBeChecked();
+
+        await page.locator(ORDER_SELECT_1).selectOption('shield');
+        await page.locator(ORDER_SELECT_2).selectOption('token');
+        await saveAndWait(page);
+
+        let stored = await helpers.getCheckOrder(request);
+        expect(stored.order, 'reorder must persist').toEqual(['shield', 'token', 'ai']);
+
+        await page.reload();
+        await expect(page.locator(ORDER_SELECT_1)).toHaveValue('shield');
+        await expect(page.locator(ORDER_SELECT_2)).toHaveValue('token');
+        await expect(page.locator(ORDER_SELECT_3)).toHaveValue('ai');
+
+        // Duplicate selection: 'shield' in two slots cannot persist — the save
+        // must fall back to the default order.
+        await page.locator(ORDER_SELECT_2).selectOption('shield');
+        await saveAndWait(page);
+
+        stored = await helpers.getCheckOrder(request);
+        expect(stored.order, 'a duplicated selection must fall back to the default order').toEqual([
+            'token',
+            'shield',
+            'ai',
+        ]);
+
+        await page.reload();
+        await expect(page.locator(ORDER_SELECT_1)).toHaveValue('token');
+        await expect(page.locator(ORDER_SELECT_2)).toHaveValue('shield');
+        await expect(page.locator(ORDER_SELECT_3)).toHaveValue('ai');
+    });
+
+    test('HP-74: order settings save while Shield is absent, with the skipped-check note shown', async ({
+        page,
+        request,
+    }) => {
+        await helpers.resetShieldMock(request);
+
+        await page.goto(PLUGIN_SETTINGS_URL);
+
+        await expect(
+            page.locator(`text=${SHIELD_SKIPPED_TEXT}`).first(),
+            'unavailable Shield must be called out as skipped'
+        ).toBeVisible();
+
+        await page.locator(ORDER_SELECT_1).selectOption('ai');
+        await page.locator(ORDER_SELECT_2).selectOption('token');
+        await page.locator(ORDER_SELECT_3).selectOption('shield');
+        await saveAndWait(page);
+
+        const stored = await helpers.getCheckOrder(request);
+        expect(
+            stored.order,
+            'the order must persist even while Shield is absent'
+        ).toEqual(['ai', 'token', 'shield']);
+
+        await page.reload();
+        await expect(page.locator(ORDER_SELECT_1)).toHaveValue('ai');
+        await expect(page.locator(ORDER_SELECT_2)).toHaveValue('token');
+        await expect(page.locator(ORDER_SELECT_3)).toHaveValue('shield');
+    });
+});


### PR DESCRIPTION
Integrates Shield Security's silentCAPTCHA as an additional spam signal and adds pipeline controls for all of the plugin's spam checks.

This supersedes #58 (the original integration and commits are preserved) by building on it with various fixes and improvements.

## What's included

**Shield silentCAPTCHA integration** (Paul's contribution): when Shield Security is active, its bot verdict flags entries as spam and aborts Save & Continue drafts. Global default + per-form override with inheritance; fail-open by design (strict `true` verdict required; Shield absent, erroring, or returning garbage never blocks a submission).

**Spam Check Order settings** (new): choose the order the token check, Shield silentCAPTCHA, and AI Spam Review run in, plus a "Stop after first detection" toggle. When stop is off, every check records its verdict as an entry note. AI rescue runs in every configuration (a rescue-only late hook covers orders that place AI before the token check).

**Master gate** (new): the per-form "Prevent spam using Gravity Forms Zero Spam" setting now gates all checks — token, Shield, and AI — at runtime and hides the dependent fields, resolved through the public `gf_zero_spam_check_key_field` filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Shield silentCAPTCHA integration as an optional spam check (global and per-form).
  * Introduced configurable “Spam Check Order” with “stop after first detection”.
  * Added AI Spam Review support for entries already flagged by another detector, including confidence notes.
  * Master “Prevent spam using Gravity Forms Zero Spam” disables all spam checks for the form.
* **Bug Fixes**
  * Improved behavior when Shield isn’t installed/present, preserving prior settings and failing open.
  * Fixed clearing of an existing spam verdict during certain logged-in entry edits.
* **Documentation**
  * Updated setup/FAQ/changelog for Shield and check-order behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->