### PR TITLE
Release 1.10.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,10 @@ jobs:
             npx @gravitykit/gktools npm install
             npx @gravitykit/gktools composer install
       - run:
+          # A Stable tag lagging the plugin header ships nothing to wp.org.
+          name: Verify release version consistency
+          command: npx @gravitykit/gktools verify
+      - run:
           name: Lint
           command: |
             npm run lint

--- a/assets/js/token-injection.js
+++ b/assets/js/token-injection.js
@@ -100,6 +100,13 @@
 				return Promise.resolve(data);
 			}
 
+			// The server only checks the token on final submission and Save and Continue,
+			// so page navigation skips the blocking fetch. Skip-list on purpose: an
+			// unknown or missing submissionType must still fetch, never the reverse.
+			if ('next' === data.submissionType || 'previous' === data.submissionType) {
+				return Promise.resolve(data);
+			}
+
 			return fetchToken(cfg).then((token) => {
 				injectToken(data.form, token);
 				return data;
@@ -119,6 +126,17 @@
 
 		formEl.dataset.gfzsBound = '1';
 		formEl.addEventListener('submit', function (e) {
+			// Same skip rule as the GF 2.9+ path: page navigation (target page > 0)
+			// never consumes the token, but Save and Continue (gform_save) does.
+			const targetInput = this.querySelector('input[name="gform_target_page_number_' + cfg.formId + '"]');
+			const saveInput = this.querySelector('input[name="gform_save"]');
+			const isNavigation = targetInput && parseInt(targetInput.value, 10) > 0;
+			const isSave = saveInput && '1' === String(saveInput.value);
+
+			if (isNavigation && !isSave) {
+				return;
+			}
+
 			e.preventDefault();
 
 			fetchToken(cfg).then((token) => {

--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Gravity Forms Zero Spam
  * Plugin URI:        https://www.gravitykit.com?utm_source=plugin&utm_campaign=zero-spam&utm_content=pluginuri
  * Description:       Enhance Gravity Forms to include effective anti-spam measures—without using a CAPTCHA.
- * Version:           1.10.0
+ * Version:           1.10.1
  * Author:            GravityKit
  * Author URI:        https://www.gravitykit.com?utm_source=plugin&utm_campaign=zero-spam&utm_content=authoruri
  * Requires PHP:      7.4

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,10 @@ You can enable a spam summary report email. This email will be sent to the email
 
 == Changelog ==
 
+= TBD =
+
+* Fixed: Multi-page forms fetched an anti-spam token on every Next and Previous click, delaying page navigation on slow servers; the token is now only fetched on final submission and Save and Continue
+
 = 1.10.0 on July 23, 2026 =
 
 * Added: [Shield silentCAPTCHA integration](https://www.gravitykit.com/docs/gravity-forms-zero-spam/shield-silentcaptcha/) that uses Shield Security's bot detection as an additional spam signal, with a global default and per-form override (thanks, Paul Goodchild!)

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: gravityview
 Tags: gravity forms, spam, captcha, honeypot, anti-spam
 Requires at least: 4.7
 Tested up to: 7.0.2
-Stable tag: 1.9.0
+Stable tag: 1.10.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: gravityview
 Tags: gravity forms, spam, captcha, honeypot, anti-spam
 Requires at least: 4.7
-Tested up to: 7.0.2
-Stable tag: 1.10.0
+Tested up to: 7.0.3
+Stable tag: 1.10.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -107,7 +107,7 @@ You can enable a spam summary report email. This email will be sent to the email
 
 == Changelog ==
 
-= TBD =
+= 1.10.1 on August 6, 2026 =
 
 * Fixed: Multi-page forms fetched an anti-spam token on every Next and Previous click, delaying page navigation on slow servers; the token is now only fetched on final submission and Save and Continue
 


### PR DESCRIPTION
* Fixed: Multi-page forms fetched an anti-spam token on every Next and Previous click, delaying page navigation on slow servers; the token is now only fetched on final submission and Save and Continue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-page form navigation by preventing unnecessary anti-spam token requests when selecting **Next** or **Previous**.
  * Anti-spam tokens continue to be handled correctly for final submissions and Save and Continue.

* **Release**
  * Updated the plugin to version 1.10.1.
  * Updated compatibility information for WordPress 7.0.3 and documented the form-navigation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/scgg74dtsnb2gnsw51670/gravity-forms-zero-spam-1.10.1-fa854b5.zip?rlkey=syhu2s47cw9rmdr4q779vxcta&dl=1) (fa854b5).